### PR TITLE
Changed return of the facter script.

### DIFF
--- a/lib/facter/collector_service_installed.rb
+++ b/lib/facter/collector_service_installed.rb
@@ -1,8 +1,0 @@
-require 'facter'
-
-Facter.add(:collector_service_installed) do
-  confine :kernel => 'Linux'
-  setcode do
-    return ::File.exist?('/etc/init.d/dynaTraceCollector')
-  end
-end

--- a/lib/facter/dynatrace_collector_service_installed.rb
+++ b/lib/facter/dynatrace_collector_service_installed.rb
@@ -1,0 +1,8 @@
+require 'facter'
+
+Facter.add(:dynatrace_collector_service_installed) do
+  confine :kernel => "Linux"
+  setcode do
+    ::File.exist?('/etc/init.d/dynaTraceCollector')
+  end
+end

--- a/lib/facter/dynatrace_server_service_installed.rb
+++ b/lib/facter/dynatrace_server_service_installed.rb
@@ -1,0 +1,8 @@
+require 'facter'
+
+Facter.add(:dynatrace_server_service_installed) do
+  confine :kernel => "Linux"
+  setcode do
+    ::File.exist?('/etc/init.d/dynaTraceServer')
+  end
+end

--- a/lib/facter/dynatrace_wsagent_service_installed.rb
+++ b/lib/facter/dynatrace_wsagent_service_installed.rb
@@ -1,0 +1,8 @@
+require 'facter'
+
+Facter.add(:dynatrace_wsagent_service_installed) do
+  confine :kernel => "Linux"
+  setcode do
+    ::File.exist?('/etc/init.d/dynaTraceWebServerAgent')
+  end
+end

--- a/lib/facter/server_service_installed.rb
+++ b/lib/facter/server_service_installed.rb
@@ -1,8 +1,0 @@
-require 'facter'
-
-Facter.add(:server_service_installed) do
-  confine :kernel => 'Linux'
-  setcode do
-    return ::File.exist?('/etc/init.d/dynaTraceServer')
-  end
-end

--- a/lib/facter/wsagent_service_installed.rb
+++ b/lib/facter/wsagent_service_installed.rb
@@ -1,8 +1,0 @@
-require 'facter'
-
-Facter.add(:wsagent_service_installed) do
-  confine :kernel => 'Linux'
-  setcode do
-    return ::File.exist?('/etc/init.d/dynaTraceWebServerAgent')
-  end
-end

--- a/manifests/role/collector.pp
+++ b/manifests/role/collector.pp
@@ -49,7 +49,7 @@ class dynatrace::role::collector (
     before  => Dynatrace_installation["Install the ${role_name}"]
   }
 
-  if $::collector_service_installed {
+  if $::dynatrace_collector_service_installed {
     service { "Stop and disable the ${role_name}'s service(s): '$service'":
       name      => $service,
       ensure    => stopped,

--- a/manifests/role/server.pp
+++ b/manifests/role/server.pp
@@ -56,7 +56,7 @@ class dynatrace::role::server (
     before  => Dynatrace_installation["Install the ${role_name}"]
   }
 
-  if $::server_service_installed {
+  if $::dynatrace_server_service_installed {
     service { "Stop and disable the ${role_name}'s service(s): '$service'":
       name      => $service,
       ensure    => stopped,

--- a/manifests/role/wsagent_package.pp
+++ b/manifests/role/wsagent_package.pp
@@ -47,7 +47,7 @@ class dynatrace::role::wsagent_package (
     before  => Dynatrace_installation["Install the ${role_name}"]
   }
 
-  if $::wsagent_service_installed {
+  if $::dynatrace_wsagent_service_installed {
     service { "Stop and disable the ${role_name}'s service(s): '$service'":
       name      => $service,
       ensure    => stopped,


### PR DESCRIPTION
We had to redo that part as this was giving errors ("Could not retrieve fact='server_service_installed', resolution='<anonymous>': ...). This was solved by removing the return statement.
We also renamed the facts as we want to avoid conflict (facts are global).
No return statement needed.
Added facter naming changes where they are used
Changed to coherant naming.