### PR TITLE
Adding project files

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>dynatrace</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.puppetlabs.geppetto.pp.dsl.ui.puppetNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,10 @@
   "source": "https://github.com/Dynatrace/Dynatrace-Puppet",
   "project_page": "https://github.com/Dynatrace/Dynatrace-Puppet",
   "issues_url": "https://github.com/Dynatrace/Dynatrace-Puppet/issues",
-  "dependencies": []
+  "dependencies": [
+  	{"name":"puppetlabs/apache","version_requirement":">=1.0.0"},
+  	{"name":"puppetlabs/java","version_requirement":">=1.0.0"},
+  	{"name":"puppetlabs/stdlib","version_requirement":">=4.1.0 < 5.0.0"},
+  	{"name":"mstrauss/editfile","version_requirement":">=0.1.0"}
+  ]
 }


### PR DESCRIPTION
To make it easier to work with IDE (Geppetto in my case) I added a .project file to the project (which is a standard practice in Puppet) and added missing dependencies in metadata.json.

The dependencies to puppetlabs/apache and puppetlabs/java are actually optional (and only used in tests) but there is no way as far as I know to mark dependencies as optional in metadata.json. I'm not completely sure what is the best approach here.