### PR TITLE
Adding ensure parameter to agents package

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>dynatrace</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.puppetlabs.geppetto.pp.dsl.ui.puppetNature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/manifests/resource/configure_init_script.pp
+++ b/manifests/resource/configure_init_script.pp
@@ -1,4 +1,10 @@
-define dynatrace::resource::configure_init_script($installer_prefix_dir = nil, $role_name = nil, $owner = nil, $group = nil) {
+define dynatrace::resource::configure_init_script(
+  $ensure               = 'present',
+  $installer_prefix_dir = nil,
+  $role_name            = nil,
+  $owner                = nil,
+  $group                = nil,
+) {
   case $::kernel {
     'Linux': {
       case $::osfamily {
@@ -14,7 +20,14 @@ define dynatrace::resource::configure_init_script($installer_prefix_dir = nil, $
     }
   }
 
+  $link_ensure = $ensure ? {
+    'present' => 'link',
+    'absent'  => 'absent',
+    default   => 'link'
+  }
+
   file { "Configure and copy the ${role_name}'s '${name}' init script":
+    ensure  => $ensure,
     path    => "${installer_prefix_dir}/dynatrace/init.d/${name}",
     owner   => $owner,
     group   => $group,
@@ -24,9 +37,9 @@ define dynatrace::resource::configure_init_script($installer_prefix_dir = nil, $
   }
 
   file { "Make the '${name}' init script available in /etc/init.d":
+    ensure  => $link_ensure,
     path    => "/etc/init.d/${name}",
     target  => "${installer_prefix_dir}/dynatrace/init.d/${name}",
-    ensure  => link,
     require => File["Configure and copy the ${role_name}'s '${name}' init script"]
   }
 }

--- a/manifests/resource/copy_or_download_file.pp
+++ b/manifests/resource/copy_or_download_file.pp
@@ -1,22 +1,35 @@
-define dynatrace::resource::copy_or_download_file($file_name, $file_url, $path) {
-  exec { "Check for the presence of ${path}":
-    command => '/bin/false',
-    returns => 1,
-    unless  => "/usr/bin/test -e ${path}"
-  }
-
-  if $file_url {
-    exec { "Download ${file_url} to ${path}":
-      command => "/usr/bin/wget -q ${file_url} -O ${path}",
-      creates => $path,
-      require => Exec["Check for the presence of ${path}"]
-    }
+define dynatrace::resource::copy_or_download_file(
+  $ensure = 'present',
+  $file_name,
+  $file_url,
+  $path,
+) {
+  validate_re($ensure, ['^present$', '^absent$'])  
+  validate_absolute_path($path)
+  if $ensure == present {
+	  exec { "Check for the presence of ${path}":
+	    command => '/bin/false',
+	    returns => 1,
+	    unless  => "/usr/bin/test -e ${path}"
+	  }
+	
+	  if $file_url {
+	    exec { "Download ${file_url} to ${path}":
+	      command => "/usr/bin/wget -q ${file_url} -O ${path}",
+	      creates => $path,
+	      require => Exec["Check for the presence of ${path}"]
+	    }
+	  } else {
+	    file { "Copy ${file_name} to ${path}":
+	      path   => $path,
+	      source => "puppet:///modules/dynatrace/${file_name}",
+	      ensure => present,
+	      require => Exec["Check for the presence of ${path}"]
+	    }
+	  }
   } else {
-    file { "Copy ${file_name} to ${path}":
-      path   => $path,
-      source => "puppet:///modules/dynatrace/${file_name}",
-      ensure => present,
-      require => Exec["Check for the presence of ${path}"]
+    file { $path:
+      ensure => 'absent',
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,10 @@
   "source": "https://github.com/Dynatrace/Dynatrace-Puppet",
   "project_page": "https://github.com/Dynatrace/Dynatrace-Puppet",
   "issues_url": "https://github.com/Dynatrace/Dynatrace-Puppet/issues",
-  "dependencies": []
+  "dependencies": [
+  	{"name":"puppetlabs/apache","version_requirement":">=1.0.0"},
+  	{"name":"puppetlabs/java","version_requirement":">=1.0.0"},
+  	{"name":"puppetlabs/stdlib","version_requirement":">=4.1.0 < 5.0.0"},
+  	{"name":"mstrauss/editfile","version_requirement":">=0.1.0"}
+  ]
 }


### PR DESCRIPTION
This is done as a proof of concept, same approach could / should be replicated to other resources.

The idea is that to keep the declarative nature of Puppet, each defined type should manage the full lifecycle of the resources it manages. This enable us to remove a lot of `if`s in the code and just pass the correct value to `$ensure` instead.

Let me know if you find this idea useful or not. Depending on your answer, I can replicate this mechanism to most resources in puppet-dynatrace.

Note that this PR is created on top of #5. I can rebase it on master if you want ...