### PR TITLE
Parameters are initialized in $dynatrace::params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,62 @@
-class dynatrace {
-  require dynatrace::params
+class dynatrace (
+  $agents_package_installer_prefix_dir = $dynatrace::params::agents_package_installer_prefix_dir,
+  $agents_package_installer_file_name  = $dynatrace::params::agents_package_installer_file_name,
+  $agents_package_installer_file_url   = $dynatrace::params::agents_package_installer_file_url,
+
+  $apache_wsagent_apache_config_file_path     = $dynatrace::params::apache_wsagent_apache_config_file_path,
+  $apache_wsagent_apache_init_script_path     = $dynatrace::params::apache_wsagent_apache_init_script_path,
+  $apache_wsagent_apache_do_patch_init_script = $dynatrace::params::apache_wsagent_apache_do_patch_init_script,
+  $apache_wsagent_linux_agent_path            = $dynatrace::params::apache_wsagent_linux_agent_path,
+
+  $collector_installer_bitsize    = $dynatrace::params::collector_installer_bitsize,
+  $collector_installer_prefix_dir = $dynatrace::params::collector_installer_prefix_dir,
+  $collector_installer_file_name  = $dynatrace::params::collector_installer_file_name,
+  $collector_installer_file_url   = $dynatrace::params::collector_installer_file_url,
+  $collector_agent_port           = $dynatrace::params::collector_agent_port,
+  $collector_server_hostname      = $dynatrace::params::collector_server_hostname,
+  $collector_server_port          = $dynatrace::params::collector_server_port,
+  $collector_jvm_xms              = $dynatrace::params::collector_jvm_xms,
+  $collector_jvm_xmx              = $dynatrace::params::collector_jvm_xmx,
+  $collector_jvm_perm_size        = $dynatrace::params::collector_jvm_perm_size,
+  $collector_jvm_max_perm_size    = $dynatrace::params::collector_jvm_max_perm_size,
+
+  $java_agent_env_var_name       = $dynatrace::params::java_agent_env_var_name,
+  $java_agent_env_var_file_name  = $dynatrace::params::java_agent_env_var_file_name,
+  $java_agent_name               = $dynatrace::params::java_agent_name,
+  $java_agent_collector_hostname = $dynatrace::params::java_agent_collector_hostname,
+  $java_agent_collector_port     = $dynatrace::params::java_agent_collector_port,
+  $java_agent_linux_agent_path   = $dynatrace::params::java_agent_linux_agent_path,
+
+  $memory_analysis_server_installer_bitsize    = $dynatrace::params::memory_analysis_server_installer_bitsize,
+  $memory_analysis_server_installer_prefix_dir = $dynatrace::params::memory_analysis_server_installer_prefix_dir,
+  $memory_analysis_server_installer_file_name  = $dynatrace::params::memory_analysis_server_installer_file_name,
+  $memory_analysis_server_installer_file_url   = $dynatrace::params::memory_analysis_server_installer_file_url,
+  $memory_analysis_server_server_port          = $dynatrace::params::memory_analysis_server_server_port,
+  $memory_analysis_server_jvm_xms              = $dynatrace::params::memory_analysis_server_jvm_xms,
+  $memory_analysis_server_jvm_xmx              = $dynatrace::params::memory_analysis_server_jvm_xmx,
+  $memory_analysis_server_jvm_perm_size        = $dynatrace::params::memory_analysis_server_jvm_perm_size,
+  $memory_analysis_server_jvm_max_perm_size    = $dynatrace::params::memory_analysis_server_jvm_max_perm_size,
+
+  $server_installer_prefix_dir = $dynatrace::params::server_installer_prefix_dir,
+  $server_installer_file_name  = $dynatrace::params::server_installer_file_name,
+  $server_installer_file_url   = $dynatrace::params::server_installer_file_url,
+  $server_license_file_name    = $dynatrace::params::server_license_file_name,
+  $server_license_file_url     = $dynatrace::params::server_license_file_url,
+  $server_collector_port       = $dynatrace::params::server_collector_port,
+  $server_do_pwh_connection    = $dynatrace::params::server_do_pwh_connection,
+  $server_pwh_connection_hostname = $dynatrace::params::server_pwh_connection_hostname,
+  $server_pwh_connection_port     = $dynatrace::params::server_pwh_connection_port,
+  $server_pwh_connection_dbms     = $dynatrace::params::server_pwh_connection_dbms,
+  $server_pwh_connection_database = $dynatrace::params::server_pwh_connection_database,
+  $server_pwh_connection_username = $dynatrace::params::server_pwh_connection_username,
+  $server_pwh_connection_password = $dynatrace::params::server_pwh_connection_password,
+
+  $wsagent_package_agent_name           = $dynatrace::params::wsagent_package_agent_name,
+  $wsagent_package_collector_hostname   = $dynatrace::params::wsagent_package_collector_hostname,
+  $wsagent_package_collector_port       = $dynatrace::params::wsagent_package_collector_port,
+  $wsagent_package_installer_prefix_dir = $dynatrace::params::wsagent_package_installer_prefix_dir,
+  $wsagent_package_installer_file_name  = $dynatrace::params::wsagent_package_installer_file_name,
+  $wsagent_package_installer_file_url   = $dynatrace::params::wsagent_package_installer_file_url,
+) inherits dynatrace::params {
+  
 }

--- a/manifests/role/agents_package.pp
+++ b/manifests/role/agents_package.pp
@@ -1,11 +1,11 @@
 class dynatrace::role::agents_package (
   $role_name            = 'Dynatrace Agents',
-  $installer_prefix_dir = $dynatrace::params::agents_package_installer_prefix_dir,
-  $installer_file_name  = $dynatrace::params::agents_package_installer_file_name,
-  $installer_file_url   = $dynatrace::params::agents_package_installer_file_url,
-  $dynatrace_owner      = $dynatrace::params::dynatrace_owner,
-  $dynatrace_group      = $dynatrace::params::dynatrace_group
-) inherits dynatrace::params {
+  $installer_prefix_dir = $dynatrace::agents_package_installer_prefix_dir,
+  $installer_file_name  = $dynatrace::agents_package_installer_file_name,
+  $installer_file_url   = $dynatrace::agents_package_installer_file_url,
+  $dynatrace_owner      = $dynatrace::dynatrace_owner,
+  $dynatrace_group      = $dynatrace::dynatrace_group
+){
 
   validate_string($installer_prefix_dir, $installer_file_name)
 

--- a/manifests/role/apache_wsagent.pp
+++ b/manifests/role/apache_wsagent.pp
@@ -1,7 +1,7 @@
 class dynatrace::role::apache_wsagent (
   $role_name                   = 'Dynatrace Apache WebServer Agent',
-  $apache_config_file_path     = $dynatrace::params::apache_wsagent_apache_config_file_path
-) inherits dynatrace::params {
+  $apache_config_file_path     = $dynatrace::apache_wsagent_apache_config_file_path
+) {
   
   validate_string($apache_config_file_path)
 

--- a/manifests/role/collector.pp
+++ b/manifests/role/collector.pp
@@ -1,19 +1,19 @@
 class dynatrace::role::collector (
   $role_name            = 'Dynatrace Collector',
-  $installer_bitsize    = $dynatrace::params::collector_installer_bitsize,
-  $installer_prefix_dir = $dynatrace::params::collector_installer_prefix_dir,
-  $installer_file_name  = $dynatrace::params::collector_installer_file_name,
-  $installer_file_url   = $dynatrace::params::collector_installer_file_url,
-  $agent_port           = $dynatrace::params::collector_agent_port,
-  $server_hostname      = $dynatrace::params::collector_server_hostname,
-  $server_port          = $dynatrace::params::collector_server_port,
-  $jvm_xms              = $dynatrace::params::collector_jvm_xms,
-  $jvm_xmx              = $dynatrace::params::collector_jvm_xmx,
-  $jvm_perm_size        = $dynatrace::params::collector_jvm_perm_size,
-  $jvm_max_perm_size    = $dynatrace::params::collector_jvm_max_perm_size,
-  $dynatrace_owner      = $dynatrace::params::dynatrace_owner,
-  $dynatrace_group      = $dynatrace::params::dynatrace_group
-) inherits dynatrace::params {
+  $installer_bitsize    = $dynatrace::collector_installer_bitsize,
+  $installer_prefix_dir = $dynatrace::collector_installer_prefix_dir,
+  $installer_file_name  = $dynatrace::collector_installer_file_name,
+  $installer_file_url   = $dynatrace::collector_installer_file_url,
+  $agent_port           = $dynatrace::collector_agent_port,
+  $server_hostname      = $dynatrace::collector_server_hostname,
+  $server_port          = $dynatrace::collector_server_port,
+  $jvm_xms              = $dynatrace::collector_jvm_xms,
+  $jvm_xmx              = $dynatrace::collector_jvm_xmx,
+  $jvm_perm_size        = $dynatrace::collector_jvm_perm_size,
+  $jvm_max_perm_size    = $dynatrace::collector_jvm_max_perm_size,
+  $dynatrace_owner      = $dynatrace::dynatrace_owner,
+  $dynatrace_group      = $dynatrace::dynatrace_group
+) {
   
   validate_re($installer_bitsize, ['^32', '64'])
   validate_string($installer_prefix_dir, $installer_file_name)

--- a/manifests/role/dynatrace_user.pp
+++ b/manifests/role/dynatrace_user.pp
@@ -1,7 +1,7 @@
 class dynatrace::role::dynatrace_user(
-  $dynatrace_owner = $dynatrace::params::dynatrace_owner,
-  $dynatrace_group = $dynatrace::params::dynatrace_group
-) inherits dynatrace::params {
+  $dynatrace_owner = $dynatrace::dynatrace_owner,
+  $dynatrace_group = $dynatrace::dynatrace_group
+) {
 
   validate_string($dynatrace_owner, $dynatrace_group)
 

--- a/manifests/role/java_agent.pp
+++ b/manifests/role/java_agent.pp
@@ -1,11 +1,11 @@
 class dynatrace::role::java_agent (
   $role_name          = 'Dynatrace Java Agent',
-  $env_var_name       = $dynatrace::params::java_agent_env_var_name,
-  $env_var_file_name  = $dynatrace::params::java_agent_env_var_file_name,
-  $agent_name         = $dynatrace::params::java_agent_name,
-  $collector_hostname = $dynatrace::params::java_agent_collector_hostname,
-  $collector_port     = $dynatrace::params::java_agent_collector_port
-) inherits dynatrace::params {
+  $env_var_name       = $dynatrace::java_agent_env_var_name,
+  $env_var_file_name  = $dynatrace::java_agent_env_var_file_name,
+  $agent_name         = $dynatrace::java_agent_name,
+  $collector_hostname = $dynatrace::java_agent_collector_hostname,
+  $collector_port     = $dynatrace::java_agent_collector_port
+){
   
   validate_string($env_var_name, $env_var_file_name)
   validate_string($agent_name, $collector_hostname, $collector_port)

--- a/manifests/role/memory_analysis_server.pp
+++ b/manifests/role/memory_analysis_server.pp
@@ -1,17 +1,17 @@
 class dynatrace::role::memory_analysis_server (
   $role_name            = 'Dynatrace Memory Analysis Server',
-  $installer_bitsize    = $dynatrace::params::memory_analysis_server_installer_bitsize,
-  $installer_prefix_dir = $dynatrace::params::memory_analysis_server_installer_prefix_dir,
-  $installer_file_name  = $dynatrace::params::memory_analysis_server_installer_file_name,
-  $installer_file_url   = $dynatrace::params::memory_analysis_server_installer_file_url,
-  $server_port          = $dynatrace::params::memory_analysis_server_server_port,
-  $jvm_xms              = $dynatrace::params::memory_analysis_server_jvm_xms,
-  $jvm_xmx              = $dynatrace::params::memory_analysis_server_jvm_xmx,
-  $jvm_perm_size        = $dynatrace::params::memory_analysis_server_jvm_perm_size,
-  $jvm_max_perm_size    = $dynatrace::params::memory_analysis_server_jvm_max_perm_size,
-  $dynatrace_owner      = $dynatrace::params::dynatrace_owner,
-  $dynatrace_group      = $dynatrace::params::dynatrace_group
-) inherits dynatrace::params {
+  $installer_bitsize    = $dynatrace::memory_analysis_server_installer_bitsize,
+  $installer_prefix_dir = $dynatrace::memory_analysis_server_installer_prefix_dir,
+  $installer_file_name  = $dynatrace::memory_analysis_server_installer_file_name,
+  $installer_file_url   = $dynatrace::memory_analysis_server_installer_file_url,
+  $server_port          = $dynatrace::memory_analysis_server_server_port,
+  $jvm_xms              = $dynatrace::memory_analysis_server_jvm_xms,
+  $jvm_xmx              = $dynatrace::memory_analysis_server_jvm_xmx,
+  $jvm_perm_size        = $dynatrace::memory_analysis_server_jvm_perm_size,
+  $jvm_max_perm_size    = $dynatrace::memory_analysis_server_jvm_max_perm_size,
+  $dynatrace_owner      = $dynatrace::dynatrace_owner,
+  $dynatrace_group      = $dynatrace::dynatrace_group
+) {
   
   validate_re($installer_bitsize, ['^32', '64'])
   validate_string($installer_prefix_dir, $installer_file_name)

--- a/manifests/role/server.pp
+++ b/manifests/role/server.pp
@@ -1,21 +1,21 @@
 class dynatrace::role::server (
   $role_name               = 'Dynatrace Server',
-  $installer_prefix_dir    = $dynatrace::params::server_installer_prefix_dir,
-  $installer_file_name     = $dynatrace::params::server_installer_file_name,
-  $installer_file_url      = $dynatrace::params::server_installer_file_url,
-  $license_file_name       = $dynatrace::params::server_license_file_name,
-  $license_file_url        = $dynatrace::params::server_license_file_url,
-  $collector_port          = $dynatrace::params::server_collector_port,
-  $do_pwh_connection       = $dynatrace::params::server_do_pwh_connection,
-  $pwh_connection_hostname = $dynatrace::params::server_pwh_connection_hostname,
-  $pwh_connection_port     = $dynatrace::params::server_pwh_connection_port,
-  $pwh_connection_dbms     = $dynatrace::params::server_pwh_connection_dbms,
-  $pwh_connection_database = $dynatrace::params::server_pwh_connection_database,
-  $pwh_connection_username = $dynatrace::params::server_pwh_connection_username,
-  $pwh_connection_password = $dynatrace::params::server_pwh_connection_password,
-  $dynatrace_owner         = $dynatrace::params::dynatrace_owner,
-  $dynatrace_group         = $dynatrace::params::dynatrace_group
-) inherits dynatrace::params {
+  $installer_prefix_dir    = $dynatrace::server_installer_prefix_dir,
+  $installer_file_name     = $dynatrace::server_installer_file_name,
+  $installer_file_url      = $dynatrace::server_installer_file_url,
+  $license_file_name       = $dynatrace::server_license_file_name,
+  $license_file_url        = $dynatrace::server_license_file_url,
+  $collector_port          = $dynatrace::server_collector_port,
+  $do_pwh_connection       = $dynatrace::server_do_pwh_connection,
+  $pwh_connection_hostname = $dynatrace::server_pwh_connection_hostname,
+  $pwh_connection_port     = $dynatrace::server_pwh_connection_port,
+  $pwh_connection_dbms     = $dynatrace::server_pwh_connection_dbms,
+  $pwh_connection_database = $dynatrace::server_pwh_connection_database,
+  $pwh_connection_username = $dynatrace::server_pwh_connection_username,
+  $pwh_connection_password = $dynatrace::server_pwh_connection_password,
+  $dynatrace_owner         = $dynatrace::dynatrace_owner,
+  $dynatrace_group         = $dynatrace::dynatrace_group
+) {
   
   validate_bool($do_pwh_connection)
   validate_string($installer_prefix_dir, $installer_file_name, $license_file_name)

--- a/manifests/role/server_license.pp
+++ b/manifests/role/server_license.pp
@@ -1,11 +1,11 @@
 class dynatrace::role::server_license (
   $role_name               = 'Dynatrace Server License',
-  $installer_prefix_dir    = $dynatrace::params::server_installer_prefix_dir,
-  $license_file_name       = $dynatrace::params::server_license_file_name,
-  $license_file_url        = $dynatrace::params::server_license_file_url,
-  $dynatrace_owner         = $dynatrace::params::dynatrace_owner,
-  $dynatrace_group         = $dynatrace::params::dynatrace_group
-) inherits dynatrace::params {
+  $installer_prefix_dir    = $dynatrace::server_installer_prefix_dir,
+  $license_file_name       = $dynatrace::server_license_file_name,
+  $license_file_url        = $dynatrace::server_license_file_url,
+  $dynatrace_owner         = $dynatrace::dynatrace_owner,
+  $dynatrace_group         = $dynatrace::dynatrace_group
+) {
   
   validate_string($installer_prefix_dir, $license_file_name)
 

--- a/manifests/role/wsagent_package.pp
+++ b/manifests/role/wsagent_package.pp
@@ -1,14 +1,14 @@
 class dynatrace::role::wsagent_package (
   $role_name            = 'Dynatrace WebServer Agent',
-  $installer_prefix_dir = $dynatrace::params::wsagent_package_installer_prefix_dir,
-  $installer_file_name  = $dynatrace::params::wsagent_package_installer_file_name,
-  $installer_file_url   = $dynatrace::params::wsagent_package_installer_file_url,
-  $agent_name           = $dynatrace::params::wsagent_package_agent_name,
-  $collector_hostname   = $dynatrace::params::wsagent_package_collector_hostname,
-  $collector_port       = $dynatrace::params::wsagent_package_collector_port,
-  $dynatrace_owner      = $dynatrace::params::dynatrace_owner,
-  $dynatrace_group      = $dynatrace::params::dynatrace_group
-) inherits dynatrace::params {
+  $installer_prefix_dir = $dynatrace::wsagent_package_installer_prefix_dir,
+  $installer_file_name  = $dynatrace::wsagent_package_installer_file_name,
+  $installer_file_url   = $dynatrace::wsagent_package_installer_file_url,
+  $agent_name           = $dynatrace::wsagent_package_agent_name,
+  $collector_hostname   = $dynatrace::wsagent_package_collector_hostname,
+  $collector_port       = $dynatrace::wsagent_package_collector_port,
+  $dynatrace_owner      = $dynatrace::dynatrace_owner,
+  $dynatrace_group      = $dynatrace::dynatrace_group
+) {
   
   validate_string($installer_prefix_dir, $installer_file_name)
   validate_string($agent_name, $collector_hostname, $collector_port)


### PR DESCRIPTION
This way, we isolate logic related to default values for parameters.

All parameters are loaded in the $dynatrace class, which allows us to use automatic parameter lookup to override them via hiera (or another mechanism).

All other classes are declaring explicitely there parameters with default values coming from $dynatrace.