### PR TITLE
Back to ERB

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,7 +11,4 @@ mod 'puppetlabs-stdlib'
 mod 'puppetlabs-apache'
 mod 'puppetlabs-java'
 mod 'puppetlabs-ruby'
-
-mod 'puppet-editfile',
-  :git => 'git://github.com/mstrauss/puppet-editfile.git'
-
+mod 'AlexCline-dirtree'

--- a/manifests/resource/configure_init_script.pp
+++ b/manifests/resource/configure_init_script.pp
@@ -3,8 +3,8 @@ define dynatrace::resource::configure_init_script(
   $installer_prefix_dir = undef,
   $role_name            = undef,
   $owner                = undef,
-  $group                = undef,
-  $params               = {}
+  $group                = undef
+#  $params               = {}
 ) {
   case $::kernel {
     'Linux': {

--- a/manifests/resource/configure_init_script.pp
+++ b/manifests/resource/configure_init_script.pp
@@ -33,10 +33,11 @@ define dynatrace::resource::configure_init_script(
     owner   => $owner,
     group   => $group,
     mode    => '0755',
-    content => epp("dynatrace/init.d/${name}", merge($params, {
-      'linux_service_start_runlevels' => $linux_service_start_runlevels,
-      'linux_service_stop_runlevels'  => $linux_service_stop_runlevels
-    })),
+    content => template("dynatrace/init.d/${name}.erb"),
+#    content => epp("dynatrace/init.d/${name}", merge($params, {
+#      'linux_service_start_runlevels' => $linux_service_start_runlevels,
+#      'linux_service_stop_runlevels'  => $linux_service_stop_runlevels
+#    })),
     require => Dynatrace_installation["Install the ${role_name}"]
   }
 

--- a/manifests/resource/configure_init_script.pp
+++ b/manifests/resource/configure_init_script.pp
@@ -1,10 +1,10 @@
 define dynatrace::resource::configure_init_script(
   $ensure               = 'present',
-  $installer_prefix_dir = undef,
   $role_name            = undef,
+  $installer_prefix_dir = undef,
   $owner                = undef,
   $group                = undef,
-  $params               = {}
+  $init_scripts_params  = {}
 ) {
   case $::kernel {
     'Linux': {
@@ -20,7 +20,12 @@ define dynatrace::resource::configure_init_script(
       }
     }
   }
-  
+
+  $params = delete_undef_values(merge($init_scripts_params, {
+    'linux_service_start_runlevels' => $linux_service_start_runlevels,
+    'linux_service_stop_runlevels'  => $linux_service_stop_runlevels
+  }))
+
   $link_ensure = $ensure ? {
     'present' => 'link',
     'absent'  => 'absent',
@@ -34,10 +39,6 @@ define dynatrace::resource::configure_init_script(
     group   => $group,
     mode    => '0755',
     content => template("dynatrace/init.d/${name}.erb"),
-#    content => epp("dynatrace/init.d/${name}", merge($params, {
-#      'linux_service_start_runlevels' => $linux_service_start_runlevels,
-#      'linux_service_stop_runlevels'  => $linux_service_stop_runlevels
-#    })),
     require => Dynatrace_installation["Install the ${role_name}"]
   }
 

--- a/manifests/role/collector.pp
+++ b/manifests/role/collector.pp
@@ -101,7 +101,7 @@ class dynatrace::role::collector (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-      params               => {
+      init_scripts_params  => {
         'installer_prefix_dir' => $installer_prefix_dir,
         'agent_port'           => $agent_port,
         'server_hostname'      => $server_hostname,

--- a/manifests/role/collector.pp
+++ b/manifests/role/collector.pp
@@ -101,16 +101,16 @@ class dynatrace::role::collector (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-      params               => {
-        'installer_prefix_dir' => $installer_prefix_dir,
-        'agent_port'           => $agent_port,
-        'server_hostname'      => $server_hostname,
-        'server_port'          => $server_port,
-        'jvm_xms'              => $jvm_xms,
-        'jvm_xmx'              => $jvm_xmx,
-        'jvm_perm_size'        => $jvm_perm_size,
-        'jvm_max_perm_size'    => $jvm_max_perm_size
-      },
+#      params               => {
+#        'installer_prefix_dir' => $installer_prefix_dir,
+#        'agent_port'           => $agent_port,
+#        'server_hostname'      => $server_hostname,
+#        'server_port'          => $server_port,
+#        'jvm_xms'              => $jvm_xms,
+#        'jvm_xmx'              => $jvm_xmx,
+#        'jvm_perm_size'        => $jvm_perm_size,
+#        'jvm_max_perm_size'    => $jvm_max_perm_size
+#      },
       notify               => Service["Start and enable the ${role_name}'s service: '${service}'"]
     }
   }

--- a/manifests/role/memory_analysis_server.pp
+++ b/manifests/role/memory_analysis_server.pp
@@ -99,14 +99,14 @@ class dynatrace::role::memory_analysis_server (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-#      params               => {
-#        'installer_prefix_dir' => $installer_prefix_dir,
-#        'server_port'          => $server_port,
-#        'jvm_xms'              => $jvm_xms,
-#        'jvm_xmx'              => $jvm_xmx,
-#        'jvm_perm_size'        => $jvm_perm_size,
-#        'jvm_max_perm_size'    => $jvm_max_perm_size
-#      },
+      init_scripts_params  => {
+        'installer_prefix_dir' => $installer_prefix_dir,
+        'server_port'          => $server_port,
+        'jvm_xms'              => $jvm_xms,
+        'jvm_xmx'              => $jvm_xmx,
+        'jvm_perm_size'        => $jvm_perm_size,
+        'jvm_max_perm_size'    => $jvm_max_perm_size
+      },
       notify               => Service["Start and enable the ${role_name}'s service: '${service}'"]
     }
   }

--- a/manifests/role/memory_analysis_server.pp
+++ b/manifests/role/memory_analysis_server.pp
@@ -99,14 +99,14 @@ class dynatrace::role::memory_analysis_server (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-      params               => {
-        'installer_prefix_dir' => $installer_prefix_dir,
-        'server_port'          => $server_port,
-        'jvm_xms'              => $jvm_xms,
-        'jvm_xmx'              => $jvm_xmx,
-        'jvm_perm_size'        => $jvm_perm_size,
-        'jvm_max_perm_size'    => $jvm_max_perm_size
-      },
+#      params               => {
+#        'installer_prefix_dir' => $installer_prefix_dir,
+#        'server_port'          => $server_port,
+#        'jvm_xms'              => $jvm_xms,
+#        'jvm_xmx'              => $jvm_xmx,
+#        'jvm_perm_size'        => $jvm_perm_size,
+#        'jvm_max_perm_size'    => $jvm_max_perm_size
+#      },
       notify               => Service["Start and enable the ${role_name}'s service: '${service}'"]
     }
   }

--- a/manifests/role/server.pp
+++ b/manifests/role/server.pp
@@ -104,10 +104,10 @@ class dynatrace::role::server (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-      params               => {
-        'installer_prefix_dir' => $installer_prefix_dir,
-        'collector_port'       => $collector_port
-      },
+#      params               => {
+#        'installer_prefix_dir' => $installer_prefix_dir,
+#        'collector_port'       => $collector_port
+#      },
       notify               => Service["Start and enable the ${role_name}'s service: '${service}'"]
     }
   }

--- a/manifests/role/server.pp
+++ b/manifests/role/server.pp
@@ -104,10 +104,10 @@ class dynatrace::role::server (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-#      params               => {
-#        'installer_prefix_dir' => $installer_prefix_dir,
-#        'collector_port'       => $collector_port
-#      },
+      init_scripts_params  => {
+        'installer_prefix_dir' => $installer_prefix_dir,
+        'collector_port'       => $collector_port
+      },
       notify               => Service["Start and enable the ${role_name}'s service: '${service}'"]
     }
   }

--- a/manifests/role/wsagent_package.pp
+++ b/manifests/role/wsagent_package.pp
@@ -105,7 +105,7 @@ class dynatrace::role::wsagent_package (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-      params               => { 'installer_prefix_dir' => $installer_prefix_dir },
+#      params               => { 'installer_prefix_dir' => $installer_prefix_dir },
       notify               => Service["Start and enable the ${role_name}'s service: '${service}'"]
     }
   }

--- a/manifests/role/wsagent_package.pp
+++ b/manifests/role/wsagent_package.pp
@@ -105,7 +105,7 @@ class dynatrace::role::wsagent_package (
       installer_prefix_dir => $installer_prefix_dir,
       owner                => $dynatrace_owner,
       group                => $dynatrace_group,
-#      params               => { 'installer_prefix_dir' => $installer_prefix_dir },
+      init_scripts_params  => { 'installer_prefix_dir' => $installer_prefix_dir },
       notify               => Service["Start and enable the ${role_name}'s service: '${service}'"]
     }
   }

--- a/templates/init.d/dynaTraceAnalysis.erb
+++ b/templates/init.d/dynaTraceAnalysis.erb
@@ -12,16 +12,16 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= @linux_service_start_runlevels %>
-# Default-Stop: <%= @linux_service_stop_runlevels %>
+# Default-Start: <%= @params["linux_service_start_runlevels"] %>
+# Default-Stop: <%= @params["linux_service_stop_runlevels"] %>
 # Description: Start/Stop dynaTrace Analysis Server daemon
 ### END INIT INFO
 
 # To use this file in your environment, adjusting the following variables:
 # - DT_HOME    installation directory of dynaTrace software
 # - DT_OPTARGS optional arguments (e.g. -vm, -instance, -server, etc.)
-DT_HOME=<%= @installer_prefix_dir %>/dynatrace
-DT_OPTARGS="-Dcom.dynatrace.diagnostics.listen=:<%= @server_port %><% if @jvm_xms %> -Xms<%= @jvm_xms %><% end %><% if @jvm_xmx %> -Xmx<%= @jvm_xmx %><% end %><% if @jvm_perm_size %> -XX:PermSize=<%= @jvm_perm_size %><% end %><% if @jvm_max_perm_size %> -XX:MaxPermSize=<%= @jvm_max_perm_size %><% end %>"
+DT_HOME=<%= @params["installer_prefix_dir"] %>/dynatrace
+DT_OPTARGS="-Dcom.dynatrace.diagnostics.listen=:<%= @params["server_port"] %><% if @params["jvm_xms"] %> -Xms<%= @params["jvm_xms"] %><% end %><% if @params["jvm_xmx"] %> -Xmx<%= @params["jvm_xmx"] %><% end %><% if @params["jvm_perm_size"] %> -XX:PermSize=<%= @params["jvm_perm_size"] %><% end %><% if @params["jvm_max_perm_size"] %> -XX:MaxPermSize=<%= @params["jvm_max_perm_size"] %><% end %>"
 
 DT_PRODUCT="Memory Analysis Server"
 DT_BINARY=dtanalysisserver

--- a/templates/init.d/dynaTraceAnalysis.erb
+++ b/templates/init.d/dynaTraceAnalysis.erb
@@ -12,16 +12,16 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= $linux_service_start_runlevels %>
-# Default-Stop: <%= $linux_service_stop_runlevels %>
+# Default-Start: <%= @linux_service_start_runlevels %>
+# Default-Stop: <%= @linux_service_stop_runlevels %>
 # Description: Start/Stop dynaTrace Analysis Server daemon
 ### END INIT INFO
 
 # To use this file in your environment, adjusting the following variables:
 # - DT_HOME    installation directory of dynaTrace software
 # - DT_OPTARGS optional arguments (e.g. -vm, -instance, -server, etc.)
-DT_HOME=<%= $installer_prefix_dir %>/dynatrace
-DT_OPTARGS="-Dcom.dynatrace.diagnostics.listen=:<%= $server_port %><% if $jvm_xms { %> -Xms<%= $jvm_xms %><% } %><% if $jvm_xmx { %> -Xmx<%= $jvm_xmx %><% } %><% if $jvm_perm_size { %> -XX:PermSize=<%= $jvm_perm_size %><% } %><% if $jvm_max_perm_size { %> -XX:MaxPermSize=<%= $jvm_max_perm_size %><% } %>"
+DT_HOME=<%= @installer_prefix_dir %>/dynatrace
+DT_OPTARGS="-Dcom.dynatrace.diagnostics.listen=:<%= @server_port %><% if @jvm_xms %> -Xms<%= @jvm_xms %><% end %><% if @jvm_xmx %> -Xmx<%= @jvm_xmx %><% end %><% if @jvm_perm_size %> -XX:PermSize=<%= @jvm_perm_size %><% end %><% if @jvm_max_perm_size %> -XX:MaxPermSize=<%= @jvm_max_perm_size %><% end %>"
 
 DT_PRODUCT="Memory Analysis Server"
 DT_BINARY=dtanalysisserver

--- a/templates/init.d/dynaTraceBackendServer.erb
+++ b/templates/init.d/dynaTraceBackendServer.erb
@@ -13,8 +13,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= @linux_service_start_runlevels %>
-# Default-Stop: <%= @linux_service_stop_runlevels %>
+# Default-Start: <%= @params["linux_service_start_runlevels"] %>
+# Default-Stop: <%= @params["linux_service_stop_runlevels"] %>
 # Description: Start/Stop dynaTrace Server daemon
 ### END INIT INFO
 
@@ -22,8 +22,8 @@
 # - DT_HOME     installation directory of dynaTrace software
 # - DT_OPTARGS  optional arguments (e.g. -vm, -instance, -server, etc.)
 # - DT_INSTANCE instance name - requires port offset in DT_OPTARGS
-DT_HOME=<%= @installer_prefix_dir %>/dynatrace
-DT_OPTARGS="-listen <%= @collector_port %>"
+DT_HOME=<%= @params["installer_prefix_dir"] %>/dynatrace
+DT_OPTARGS="-listen <%= @params["collector_port"] %>"
 DT_INSTANCE=
 
 DT_PRODUCT=Server

--- a/templates/init.d/dynaTraceBackendServer.erb
+++ b/templates/init.d/dynaTraceBackendServer.erb
@@ -13,8 +13,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= $linux_service_start_runlevels %>
-# Default-Stop: <%= $linux_service_stop_runlevels %>
+# Default-Start: <%= @linux_service_start_runlevels %>
+# Default-Stop: <%= @linux_service_stop_runlevels %>
 # Description: Start/Stop dynaTrace Server daemon
 ### END INIT INFO
 
@@ -22,8 +22,8 @@
 # - DT_HOME     installation directory of dynaTrace software
 # - DT_OPTARGS  optional arguments (e.g. -vm, -instance, -server, etc.)
 # - DT_INSTANCE instance name - requires port offset in DT_OPTARGS
-DT_HOME=<%= $installer_prefix_dir %>/dynatrace
-DT_OPTARGS="-listen <%= $collector_port %>"
+DT_HOME=<%= @installer_prefix_dir %>/dynatrace
+DT_OPTARGS="-listen <%= @collector_port %>"
 DT_INSTANCE=
 
 DT_PRODUCT=Server

--- a/templates/init.d/dynaTraceCollector.erb
+++ b/templates/init.d/dynaTraceCollector.erb
@@ -13,8 +13,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= @linux_service_start_runlevels %>
-# Default-Stop: <%= @linux_service_stop_runlevels %>
+# Default-Start: <%= @params["linux_service_start_runlevels"] %>
+# Default-Stop: <%= @params["linux_service_stop_runlevels"] %>
 # Description: Start/Stop dynaTrace Collector daemon
 ### END INIT INFO
 
@@ -24,6 +24,7 @@
 # - DT_INSTANCE instance name if -instance argument is specified
 DT_HOME=<%= @params["installer_prefix_dir"] %>/dynatrace
 DT_OPTARGS="-listen <%= @params["agent_port"] %> -server <%= @params["server_hostname"] %>:<%= @params["server_port"] %><% if @params["jvm_xms"] %> -Xms<%= @params["jvm_xms"] %><% end %><% if @params["jvm_xmx"] %> -Xmx<%= @params["jvm_xmx"] %><% end %><% if @params["jvm_perm_size"] %> -XX:PermSize=<%= @params["jvm_perm_size"] %><% end %><% if @params["jvm_max_perm_size"] %> -XX:MaxPermSize=<%= @params["jvm_max_perm_size"] %><% end %>"
+
 # When using an instance name, ensure that the -instance argument from
 # DT_OPTARGS is in sync with the following DT_INSTANCE variable:
 # (e.g.: "-instance InstName" requires "DT_INSTANCE=InstName")

--- a/templates/init.d/dynaTraceCollector.erb
+++ b/templates/init.d/dynaTraceCollector.erb
@@ -13,8 +13,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= $linux_service_start_runlevels %>
-# Default-Stop: <%= $linux_service_stop_runlevels %>
+# Default-Start: <%= @linux_service_start_runlevels %>
+# Default-Stop: <%= @linux_service_stop_runlevels %>
 # Description: Start/Stop dynaTrace Collector daemon
 ### END INIT INFO
 
@@ -22,8 +22,8 @@
 # - DT_HOME     installation directory of dynaTrace software
 # - DT_OPTARGS  optional arguments (e.g. -vm, -instance, -server, etc.)
 # - DT_INSTANCE instance name if -instance argument is specified
-DT_HOME=<%= $installer_prefix_dir %>/dynatrace
-DT_OPTARGS="-listen <%= $agent_port %> -server <%= $server_hostname %>:<%= $server_port %><% if $jvm_xms { %> -Xms<%= $jvm_xms %><% } %><% if $jvm_xmx { %> -Xmx<%= $jvm_xmx %><% } %><% if $jvm_perm_size { %> -XX:PermSize=<%= $jvm_perm_size %><% } %><% if $jvm_max_perm_size { %> -XX:MaxPermSize=<%= $jvm_max_perm_size %><% } %>"
+DT_HOME=<%= @installer_prefix_dir %>/dynatrace
+DT_OPTARGS="-listen <%= @agent_port %> -server <%= @server_hostname %>:<%= @server_port %><% if @jvm_xms %> -Xms<%= @jvm_xms %><% end %><% if @jvm_xmx %> -Xmx<%= @jvm_xmx %><% end %><% if @jvm_perm_size %> -XX:PermSize=<%= @jvm_perm_size %><% end %><% if @jvm_max_perm_size %> -XX:MaxPermSize=<%= @jvm_max_perm_size %><% end %>"
 # When using an instance name, ensure that the -instance argument from
 # DT_OPTARGS is in sync with the following DT_INSTANCE variable:
 # (e.g.: "-instance InstName" requires "DT_INSTANCE=InstName")

--- a/templates/init.d/dynaTraceFrontendServer.erb
+++ b/templates/init.d/dynaTraceFrontendServer.erb
@@ -13,8 +13,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= @linux_service_start_runlevels %>
-# Default-Stop: <%= @linux_service_stop_runlevels %>
+# Default-Start: <%= @params["linux_service_start_runlevels"] %>
+# Default-Stop: <%= @params["linux_service_stop_runlevels"] %>
 # Description: Start/Stop dynaTrace FrontendServer daemon
 ### END INIT INFO
 
@@ -22,7 +22,7 @@
 # - DT_HOME     installation directory of dynaTrace software
 # - DT_OPTARGS  optional arguments (e.g. -vm, -instance, -server, etc.)
 # - DT_INSTANCE instance name - requires port offset in DT_OPTARGS
-DT_HOME=<%= @installer_prefix_dir %>/dynatrace
+DT_HOME=<%= @params["installer_prefix_dir"] %>/dynatrace
 DT_OPTARGS=
 DT_INSTANCE=
 

--- a/templates/init.d/dynaTraceFrontendServer.erb
+++ b/templates/init.d/dynaTraceFrontendServer.erb
@@ -13,8 +13,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= $linux_service_start_runlevels %>
-# Default-Stop: <%= $linux_service_stop_runlevels %>
+# Default-Start: <%= @linux_service_start_runlevels %>
+# Default-Stop: <%= @linux_service_stop_runlevels %>
 # Description: Start/Stop dynaTrace FrontendServer daemon
 ### END INIT INFO
 
@@ -22,7 +22,7 @@
 # - DT_HOME     installation directory of dynaTrace software
 # - DT_OPTARGS  optional arguments (e.g. -vm, -instance, -server, etc.)
 # - DT_INSTANCE instance name - requires port offset in DT_OPTARGS
-DT_HOME=<%= $installer_prefix_dir %>/dynatrace
+DT_HOME=<%= @installer_prefix_dir %>/dynatrace
 DT_OPTARGS=
 DT_INSTANCE=
 

--- a/templates/init.d/dynaTraceServer.erb
+++ b/templates/init.d/dynaTraceServer.erb
@@ -15,8 +15,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= $linux_service_start_runlevels %>
-# Default-Stop: <%= $linux_service_stop_runlevels %>
+# Default-Start: <%= @linux_service_start_runlevels %>
+# Default-Stop: <%= @linux_service_stop_runlevels %>
 # Description: Start/Stop dynaTrace Server/Backend Server/Frontend Server daemon
 ### END INIT INFO
 
@@ -27,8 +27,8 @@
 # - DT_INSTANCE instance name - requires port offset in DT_OPTARGS, must be equal to DT_FE_INSTANCE
 # - DT_FE_INSTANCE instance name - requires port offset in DT_FE_OPTARGS, must be equal to DT_INSTANCE
 
-DT_HOME=<%= $installer_prefix_dir %>/dynatrace
-DT_OPTARGS="-listen <%= $collector_port %>"
+DT_HOME=<%= @installer_prefix_dir %>/dynatrace
+DT_OPTARGS="-listen <%= @collector_port %>"
 DT_FE_OPTARGS=
 
 DT_INSTANCE=

--- a/templates/init.d/dynaTraceServer.erb
+++ b/templates/init.d/dynaTraceServer.erb
@@ -15,8 +15,8 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= @linux_service_start_runlevels %>
-# Default-Stop: <%= @linux_service_stop_runlevels %>
+# Default-Start: <%= @params["linux_service_start_runlevels"] %>
+# Default-Stop: <%= @params["linux_service_stop_runlevels"] %>
 # Description: Start/Stop dynaTrace Server/Backend Server/Frontend Server daemon
 ### END INIT INFO
 
@@ -27,8 +27,8 @@
 # - DT_INSTANCE instance name - requires port offset in DT_OPTARGS, must be equal to DT_FE_INSTANCE
 # - DT_FE_INSTANCE instance name - requires port offset in DT_FE_OPTARGS, must be equal to DT_INSTANCE
 
-DT_HOME=<%= @installer_prefix_dir %>/dynatrace
-DT_OPTARGS="-listen <%= @collector_port %>"
+DT_HOME=<%= @params["installer_prefix_dir"] %>/dynatrace
+DT_OPTARGS="-listen <%= @params["collector_port"] %>"
 DT_FE_OPTARGS=
 
 DT_INSTANCE=

--- a/templates/init.d/dynaTraceWebServerAgent.erb
+++ b/templates/init.d/dynaTraceWebServerAgent.erb
@@ -12,15 +12,15 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= $linux_service_start_runlevels %>
-# Default-Stop: <%= $linux_service_stop_runlevels %>
+# Default-Start: <%= @linux_service_start_runlevels %>
+# Default-Stop: <%= @linux_service_stop_runlevels %>
 # Description: Start/Stop dynaTrace WebServer Agent daemon
 ### END INIT INFO
 
 # To use this file in your environment, adjusting the following variables:
 # - DT_HOME     installation directory of dynaTrace software
 # - DT_OPTARGS  optional arguments (server, ...)
-DT_HOME=<%= $installer_prefix_dir %>/dynatrace
+DT_HOME=<%= @installer_prefix_dir %>/dynatrace
 
 DT_PRODUCT="WebServer Agent"
 DT_BINARY=dtwsagent

--- a/templates/init.d/dynaTraceWebServerAgent.erb
+++ b/templates/init.d/dynaTraceWebServerAgent.erb
@@ -12,15 +12,15 @@
 # Required-Start: $network
 # Required-Stop: $network
 # X-UnitedLinux-Should-Start:
-# Default-Start: <%= @linux_service_start_runlevels %>
-# Default-Stop: <%= @linux_service_stop_runlevels %>
+# Default-Start: <%= @params["linux_service_start_runlevels"] %>
+# Default-Stop: <%= @params["linux_service_stop_runlevels"] %>
 # Description: Start/Stop dynaTrace WebServer Agent daemon
 ### END INIT INFO
 
 # To use this file in your environment, adjusting the following variables:
 # - DT_HOME     installation directory of dynaTrace software
 # - DT_OPTARGS  optional arguments (server, ...)
-DT_HOME=<%= @installer_prefix_dir %>/dynatrace
+DT_HOME=<%= @params["installer_prefix_dir"] %>/dynatrace
 
 DT_PRODUCT="WebServer Agent"
 DT_BINARY=dtwsagent


### PR DESCRIPTION
In order to maintain support with Puppet Enterprise 3.8, we revert from EPP to properly configured ERB templates.