### PR TITLE
make cache_dir configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,6 @@
 class dynatrace (
+  $installer_cache_dir = $dynatrace::params::installer_cache_dir,
+
   $agents_package_installer_prefix_dir = $dynatrace::params::agents_package_installer_prefix_dir,
   $agents_package_installer_file_name  = $dynatrace::params::agents_package_installer_file_name,
   $agents_package_installer_file_url   = $dynatrace::params::agents_package_installer_file_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,9 @@
 # This class configures parameters for the dynatrace-dynatrace module.
 #
 # Parameters:
-#  $dynatrace_owner => The system user that owns a Dynatrace installation.
-#  $dynatrace_group => The system user's group that owns a Dynatrace installation.
+#  $dynatrace_owner     => The system user that owns a Dynatrace installation.
+#  $dynatrace_group     => The system user's group that owns a Dynatrace installation.
+#  $installer_cache_dir => The path where the installation script and downloaded jar-file will be temporarily placed
 #
 #  $agents_package_installer_prefix_dir => The Dynatrace Agents package will be installed into the directory $agents_package_installer_prefix_dir/dynatrace-$major-$minor-$rev, where $major, $minor and $rev are given by the installer. A symbolic link to the actual installation directory will be created in $agents_package_installer_prefix_dir/dynatrace.
 #  $agents_package_installer_file_name  => The file name of the Dynatrace Agents installer in the module's files directory.
@@ -68,8 +69,9 @@ class dynatrace::params {
 
   case $::kernel {
     'Linux': {
-      $dynatrace_owner = 'dynatrace'
-      $dynatrace_group = 'dynatrace'
+      $dynatrace_owner     = 'dynatrace'
+      $dynatrace_group     = 'dynatrace'
+      $installer_cache_dir = "${settings::vardir}"
 
       $agents_package_installer_prefix_dir = '/opt'
       $agents_package_installer_file_name  = 'dynatrace-agent.jar'

--- a/manifests/role/agents_package.pp
+++ b/manifests/role/agents_package.pp
@@ -17,7 +17,7 @@ class dynatrace::role::agents_package (
     }
     default: {}
   }
-  
+
   $directory_ensure = $ensure ? {
     'present' => 'directory',
     'absent'  => 'absent',
@@ -30,7 +30,7 @@ class dynatrace::role::agents_package (
     default   => 'installed',
   }
 
-  $installer_cache_dir = "${settings::vardir}/dynatrace"
+  $installer_cache_dir = "$dynatrace::installer_cache_dir/dynatrace"
   $installer_cache_dir_tree = dirtree($installer_cache_dir)
 
 

--- a/manifests/role/collector.pp
+++ b/manifests/role/collector.pp
@@ -48,7 +48,7 @@ class dynatrace::role::collector (
     default   => 'running',
   }
 
-  $installer_cache_dir = "${settings::vardir}/dynatrace"
+  $installer_cache_dir = "$dynatrace::installer_cache_dir/dynatrace"
   $installer_cache_dir_tree = dirtree($installer_cache_dir)
 
 

--- a/manifests/role/memory_analysis_server.pp
+++ b/manifests/role/memory_analysis_server.pp
@@ -46,7 +46,7 @@ class dynatrace::role::memory_analysis_server (
     default   => 'running',
   }
 
-  $installer_cache_dir = "${settings::vardir}/dynatrace"
+  $installer_cache_dir = "$dynatrace::installer_cache_dir/dynatrace"
   $installer_cache_dir_tree = dirtree($installer_cache_dir)
 
 

--- a/manifests/role/server.pp
+++ b/manifests/role/server.pp
@@ -52,7 +52,7 @@ class dynatrace::role::server (
     default   => 'running',
   }
 
-  $installer_cache_dir = "${settings::vardir}/dynatrace"
+  $installer_cache_dir = "$dynatrace::installer_cache_dir/dynatrace"
   $installer_cache_dir_tree = dirtree($installer_cache_dir)
 
 


### PR DESCRIPTION
In our installation, `/var` is mounted with `noexec`, so I had to change the cache directory.
Default stays the same, but with this PR it's configurable.