### PR TITLE
Fix the initial server setup

### DIFF
--- a/manifests/role/server.pp
+++ b/manifests/role/server.pp
@@ -68,6 +68,7 @@ class dynatrace::role::server (
     path    => "${installer_cache_dir}/${installer_script_name}",
     content => template("dynatrace/server/${installer_script_name}"),
     mode    => '0744',
+    before  => Dynatrace_installation["Install the ${role_name}"]
   }
 
   dynatrace_installation { "Install the ${role_name}":
@@ -80,7 +81,8 @@ class dynatrace::role::server (
     installer_path_detailed => '',
     installer_owner       => $dynatrace_owner,
     installer_group       => $dynatrace_group,
-    installer_cache_dir   => $installer_cache_dir
+    installer_cache_dir   => $installer_cache_dir,
+    require               => File["Configure and copy the ${role_name}'s install script"]
   }
   
   if $::kernel == 'Linux' {


### PR DESCRIPTION
In `server` manifest we need to ensure that the install script exists before executing it. Otherwise, the first converge will fail:

```
$ KITCHEN_LOCAL_YAML=./.kitchen.vagrant.yml kitchen converge server-debian-711
-----> Starting Kitchen (v1.14.2)
-----> Creating <server-debian-711>...

<...>

       Notice: Compiled catalog for server-debian-711.vagrantup.com in environment production in 0.56 seconds
       Notice: /Stage[main]/Ruby/File[ruby_bin]/target: target changed '/etc/alternatives/ruby' to '/usr/bin/ruby1.9.1'
       Notice: /Stage[main]/Java/Package[java-common]/ensure: ensure changed 'purged' to 'present'
       Notice: /Stage[main]/Ruby/Package[rubygems]/ensure: ensure changed 'purged' to 'present'
       Notice: /Stage[main]/Ruby/File[gem_bin]/target: target changed '/etc/alternatives/gem' to '/usr/bin/gem1.9.1'
       Notice: /Stage[main]/Java/Package[java]/ensure: ensure changed 'purged' to 'present'
       Checking if requires installation for path: /opt/dynatrace-6.5/server. Result: true, ensure= present
       script2exec=/var/lib/puppet/dynatrace/install-server.sh
       Error: Execution of '/var/lib/puppet/dynatrace/install-server.sh' returned 1:
       Error: /Stage[main]/Dynatrace::Role::Server/Dynatrace_installation[Install the Dynatrace Server]/ensure: change from absent to present failed: Execution of '/var/lib/puppet/dynatrace/install-server.sh' returned 1:
       Notice: /Stage[main]/Dynatrace::Role::Dynatrace_user/User[Create system user 'dynatrace']/ensure: created
       Notice: /Stage[main]/Dynatrace::Role::Server/Dynatrace::Resource::Configure_init_script[dynaTraceFrontendServer]/File[Configure and copy the Dynatrace Server's 'dynaTraceFrontendServer' init script]: Dependency Dynatrace_installation[Install the Dynatrace Server] has failures: true
       Warning: /Stage[main]/Dynatrace::Role::Server/Dynatrace::Resource::Configure_init_script[dynaTraceFrontendServer]/File[Configure and copy the Dynatrace Server's 'dynaTraceFrontendServer' init script]: Skipping because of failed dependencies
       Notice: /Stage[main]/Dynatrace::Role::Server/Dynatrace::Resource::Configure_init_script[dynaTraceServer]/File[Configure and copy the Dynatrace Server's 'dynaTraceServer' init script]: Dependency Dynatrace_installation[Install the Dynatrace Server] has failures: true
       Warning: /Stage[main]/Dynatrace::Role::Server/Dynatrace::Resource::Configure_init_script[dynaTraceServer]/File[Configure and copy the Dynatrace Server's 'dynaTraceServer' init script]: Skipping because of failed dependencies
       Notice: /Stage[main]/Dynatrace::Role::Server/Dynatrace::Resource::Configure_init_script[dynaTraceServer]/File[Make the 'dynaTraceServer' init script available in /etc/init.d]: Dependency Dynatrace_installation[Install the Dynatrace Server] has failures: true
```

P.s. The issue was reproduced on both of `server` and `server_collector_agent` TestKitchen suites.