### PR TITLE
Fix kitchen tests for Dynatrace server

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,7 +16,7 @@ platforms:
         # Install common dependencies
         - yum install -y net-tools tar wget which
         # Install ruby dependencies
-        - yum install -y git gcc-c++ libffi-devel libssl-devel openssl-devel readline-devel zlib-devel 
+        - yum install -y git gcc-c++ libffi-devel libssl-devel openssl-devel readline-devel zlib-devel
         # Install ruby 2.2.0
         - git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
         - git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build

--- a/manifests/resource/copy_or_download_file.pp
+++ b/manifests/resource/copy_or_download_file.pp
@@ -13,7 +13,7 @@ define dynatrace::resource::copy_or_download_file(
       returns => 1,
       unless  => "/usr/bin/test -e ${path}"
     }
-    
+
     if $file_url {
       wget::fetch { "Download ${file_url} to ${path}":
         source      => $file_url,

--- a/manifests/role/agents_package.pp
+++ b/manifests/role/agents_package.pp
@@ -19,7 +19,7 @@ class dynatrace::role::agents_package (
     }
     default: {}
   }
-  
+
   $directory_ensure = $ensure ? {
     'present' => 'directory',
     'absent'  => 'absent',

--- a/manifests/role/apache_wsagent.pp
+++ b/manifests/role/apache_wsagent.pp
@@ -3,7 +3,7 @@ class dynatrace::role::apache_wsagent (
   $role_name               = 'Dynatrace Apache WebServer Agent',
   $apache_config_file_path = $dynatrace::apache_wsagent_apache_config_file_path
 ) inherits dynatrace {
-  
+
   validate_re($ensure, ['^present$', '^absent$'])
   validate_string($apache_config_file_path)
 

--- a/manifests/role/collector.pp
+++ b/manifests/role/collector.pp
@@ -15,7 +15,7 @@ class dynatrace::role::collector (
   $dynatrace_owner      = $dynatrace::dynatrace_owner,
   $dynatrace_group      = $dynatrace::dynatrace_group
 ) inherits dynatrace {
-  
+
   validate_re($ensure, ['^present$', '^absent$'])
   validate_re($installer_bitsize, ['^32', '64'])
   validate_string($installer_prefix_dir, $installer_file_name)
@@ -29,7 +29,7 @@ class dynatrace::role::collector (
     }
     default: {}
   }
-  
+
   $directory_ensure = $ensure ? {
     'present' => 'directory',
     'absent'  => 'absent',
@@ -41,7 +41,7 @@ class dynatrace::role::collector (
     'absent'  => 'uninstalled',
     default   => 'installed',
   }
-  
+
   $service_ensure = $ensure ? {
     'present' => 'running',
     'absent'  => 'stopped',

--- a/manifests/role/host_agent.pp
+++ b/manifests/role/host_agent.pp
@@ -68,9 +68,9 @@ class dynatrace::role::host_agent (
     path    => ['/usr/bin', '/usr/sbin', '/bin'],
     unless  => ["test -L /etc/init.d/${service}"],
   } ->
-  service { "Enable and stop the ${role_name}'s service: '${service}'":    #hack to ensure start service (enable and stop service then start it)  
+  service { "Enable and stop the ${role_name}'s service: '${service}'":    #hack to ensure start service (enable and stop service then start it)
     ensure => running,
     name   => $service,
     enable => true
-  }  
+  }
 }

--- a/manifests/role/install_all.pp
+++ b/manifests/role/install_all.pp
@@ -8,7 +8,7 @@ class dynatrace::role::install_all (
   $license_file_name       = $dynatrace::server_license_file_name,
   $license_file_url        = $dynatrace::server_license_file_url,
   $collector_port          = $dynatrace::server_collector_port,
-  
+
   $do_pwh_connection       = $dynatrace::server_do_pwh_connection,
   $pwh_connection_hostname = $dynatrace::server_pwh_connection_hostname,
   $pwh_connection_port     = $dynatrace::server_pwh_connection_port,

--- a/manifests/role/java_agent.pp
+++ b/manifests/role/java_agent.pp
@@ -24,7 +24,7 @@ class dynatrace::role::java_agent (
   file { $env_var_file_name :
     ensure => file,
   }
-  
+
   file_line { "Inject the ${role_name} into ${env_var_file_name}":
     ensure => $ensure,
     path   => $env_var_file_name,

--- a/manifests/role/memory_analysis_server.pp
+++ b/manifests/role/memory_analysis_server.pp
@@ -13,7 +13,7 @@ class dynatrace::role::memory_analysis_server (
   $dynatrace_owner      = $dynatrace::dynatrace_owner,
   $dynatrace_group      = $dynatrace::dynatrace_group
 ) inherits dynatrace {
-  
+
   validate_re($ensure, ['^present$', '^absent$'])
   validate_re($installer_bitsize, ['^32', '64'])
   validate_string($installer_prefix_dir, $installer_file_name)
@@ -27,7 +27,7 @@ class dynatrace::role::memory_analysis_server (
     }
     default: {}
   }
-  
+
   $directory_ensure = $ensure ? {
     'present' => 'directory',
     'absent'  => 'absent',
@@ -39,7 +39,7 @@ class dynatrace::role::memory_analysis_server (
     'absent'  => 'uninstalled',
     default   => 'installed',
   }
-  
+
   $service_ensure = $ensure ? {
     'present' => 'running',
     'absent'  => 'stopped',

--- a/manifests/role/pwh_connection.pp
+++ b/manifests/role/pwh_connection.pp
@@ -14,14 +14,14 @@ class dynatrace::role::pwh_connection (
   validate_string($installer_prefix_dir, $installer_file_name, $license_file_name)
   validate_string($collector_port)
   validate_string($pwh_connection_hostname, $pwh_connection_port, $pwh_connection_dbms, $pwh_connection_database, $pwh_connection_username, $pwh_connection_password)
-    
+
   case $::kernel {
     'Linux': {
       $service = $dynatrace::dynaTraceServer
     }
     default: {}
   }
-  
+
   $service_ensure = $ensure ? {
     'present' => 'running',
     'absent'  => 'stopped',
@@ -33,7 +33,7 @@ class dynatrace::role::pwh_connection (
     name   => $service,
     enable => true
   }
-  
+
   wait_until_port_is_open { $collector_port:
     ensure  => $ensure,
     require => Service["Start and enable the ${role_name}'s service: '${service}'"]
@@ -60,7 +60,7 @@ class dynatrace::role::pwh_connection (
     ensure  => $ensure,
     require => Service["Start and enable the ${role_name}'s service: '${service}'"]
   }
-  
+
   wait_until_rest_endpoint_is_ready { 'https://localhost:8021/rest/management/pwhconnection/config':
     ensure  => $ensure,
     require => Service["Start and enable the ${role_name}'s service: '${service}'"]

--- a/manifests/role/pwh_connection.pp
+++ b/manifests/role/pwh_connection.pp
@@ -1,6 +1,6 @@
 class dynatrace::role::pwh_connection (
   $ensure                  = 'present',
-  $role_name               = 'Dynatrace Server PHW connection',
+  $role_name               = 'Dynatrace Server PWH connection',
   $collector_port          = $dynatrace::server_collector_port,
   $pwh_connection_hostname = $dynatrace::server_pwh_connection_hostname,
   $pwh_connection_port     = $dynatrace::server_pwh_connection_port,

--- a/manifests/role/server.pp
+++ b/manifests/role/server.pp
@@ -15,7 +15,7 @@ class dynatrace::role::server (
   validate_re($ensure, ['^present$', '^absent$'])
   validate_string($installer_prefix_dir, $installer_file_name, $license_file_name)
   validate_string($collector_port)
-    
+
   case $::kernel {
     'Linux': {
       $installer_script_name = 'install-server.sh'
@@ -25,7 +25,7 @@ class dynatrace::role::server (
     }
     default: {}
   }
-  
+
   $directory_ensure = $ensure ? {
     'present' => 'directory',
     'absent'  => 'absent',
@@ -37,7 +37,7 @@ class dynatrace::role::server (
     'absent'  => 'uninstalled',
     default   => 'installed',
   }
-  
+
   $service_ensure = $ensure ? {
     'present' => 'running',
     'absent'  => 'stopped',
@@ -62,7 +62,7 @@ class dynatrace::role::server (
     path      => "${installer_cache_dir}/${installer_file_name}",
     require   => File[$installer_cache_dir_tree],
   }
-  
+
   file { "Configure and copy the ${role_name}'s install script":
     ensure  => $ensure,
     path    => "${installer_cache_dir}/${installer_script_name}",
@@ -82,7 +82,7 @@ class dynatrace::role::server (
     installer_group       => $dynatrace_group,
     installer_cache_dir   => $installer_cache_dir
   }
-  
+
   if $::kernel == 'Linux' {
     dynatrace::resource::configure_init_script { $init_scripts:
       ensure               => $ensure,
@@ -104,7 +104,7 @@ class dynatrace::role::server (
     name   => $service,
     enable => true
   }
-  
+
   wait_until_port_is_open { $collector_port:
     ensure  => $ensure,
     require => Service["Start and enable the ${role_name}'s service: '${service}'"]
@@ -132,4 +132,3 @@ class dynatrace::role::server (
     require => Service["Start and enable the ${role_name}'s service: '${service}'"]
   }
 }
-

--- a/manifests/role/server_license.pp
+++ b/manifests/role/server_license.pp
@@ -7,7 +7,7 @@ class dynatrace::role::server_license (
   $dynatrace_owner      = $dynatrace::dynatrace_owner,
   $dynatrace_group      = $dynatrace::dynatrace_group
 ) inherits dynatrace {
-  
+
   validate_re($ensure, ['^present$', '^absent$'])
   validate_string($installer_prefix_dir, $license_file_name)
 

--- a/manifests/role/server_update.pp
+++ b/manifests/role/server_update.pp
@@ -3,40 +3,40 @@ class dynatrace::role::server_update (
   $role_name               = 'Dynatrace Server update',
 
   $collector_port          = $dynatrace::server_collector_port,
-    
+
   $update_file_url         = $dynatrace::update_file_url,
   $update_rest_url         = $dynatrace::update_rest_url,
   $update_user             = $dynatrace::update_user,
   $update_passwd           = $dynatrace::update_passwd,
-  
+
   $dynatrace_owner         = $dynatrace::dynatrace_owner,
   $dynatrace_group         = $dynatrace::dynatrace_group
-  
+
 ) inherits dynatrace {
 
   case $::kernel {
     'Linux': {
       $installer_script_name = 'install-server.sh'
-      
+
       $service                 = $dynatrace::dynaTraceServer
       $collectorService        = $dynatrace::dynaTraceCollector
       $dynaTraceAnalysis       = $dynatrace::dynaTraceAnalysis
       $dynaTraceWebServerAgent = $dynatrace::dynaTraceWebServerAgent
       $dynaTraceHostagent      = $dynatrace::dynaTraceHostagent
-      
+
       $installer_cache_dir = "$dynatrace::installer_cache_dir/dynatrace"
       $installer_cache_dir_tree = dirtree($installer_cache_dir)
       $update_file_path = "${installer_cache_dir}"
       $services_to_stop_array = $dynatrace::services_to_manage_array
-      
+
       $services_to_start_array = [
         $dynatrace::dynaTraceServer,
         $dynatrace::dynaTraceCollector,
-        $dynatrace::dynaTraceAnalysis,  
+        $dynatrace::dynaTraceAnalysis,
         $dynatrace::dynaTraceWebServerAgent,
         $dynatrace::dynaTraceHostagent,
 #        'dynaTraceBackendServer',
-#        'dynaTraceFrontendServer' 
+#        'dynaTraceFrontendServer'
         ]
 
     }
@@ -63,7 +63,7 @@ class dynatrace::role::server_update (
     group  => $dynatrace_group,
   }
 
-  # introducing order (archive then update and stop then start services)  
+  # introducing order (archive then update and stop then start services)
   archive { 'dynaTrace-update':
      ensure => present,
      url => $update_file_url,
@@ -84,7 +84,7 @@ class dynatrace::role::server_update (
 
   wait_until_port_is_open { $collector_port:
     ensure  => $ensure,
-  } -> 
+  } ->
 
   wait_until_port_is_open { '2021':
     ensure  => $ensure,
@@ -97,7 +97,7 @@ class dynatrace::role::server_update (
   wait_until_port_is_open { '9911':
     ensure  => $ensure,
   }
-    
+
   if $collector_port != '6699' {
     wait_until_port_is_open { '6699':
       ensure  => $ensure,

--- a/manifests/role/start_all_processes.pp
+++ b/manifests/role/start_all_processes.pp
@@ -24,11 +24,11 @@ class dynatrace::role::start_all_processes (
       $services_to_start_array = [
         $dynatrace::dynaTraceServer,
         $dynatrace::dynaTraceCollector,
-        $dynatrace::dynaTraceAnalysis,  
+        $dynatrace::dynaTraceAnalysis,
         $dynatrace::dynaTraceWebServerAgent,
         $dynatrace::dynaTraceHostagent,
 #        'dynaTraceBackendServer',
-#        'dynaTraceFrontendServer' 
+#        'dynaTraceFrontendServer'
         ]
     }
     default: {}
@@ -37,8 +37,8 @@ class dynatrace::role::start_all_processes (
   $services_to_start_array.each |$x| {
 #    if ("test -L /etc/init.d/${x}") {
 #      notify {"Service ${x} exists and will be stopped.": }
-#    }  
-#    
+#    }
+#
 #    #TODO cannot use service resource because of duplicated name in stop_all_processes
 #    service { "${role_name}: Service ${x} exists and will be started.":
 #      title  => "start_all_processes ${x}",
@@ -46,14 +46,14 @@ class dynatrace::role::start_all_processes (
 #      name   => $x,
 #      enable => true
 #    }
-    
+
 #    puts "Start the service: '${x}'"
-    
+
     exec {"Start the service: '${x}'":    #hack to ensure restart service (stop service then start it) [there is no possibility in puppet to use the same name of service in different stauses because of error 'Cannot alias Service']
       command => "service ${x} start",
       path    => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
       onlyif  => ["test -L /etc/init.d/${x}"],
-    }    
+    }
   }
 
   if $collector_port != '6699' {
@@ -61,10 +61,10 @@ class dynatrace::role::start_all_processes (
       ensure  => $ensure,
     }
   }
-    
+
   wait_until_port_is_open { $collector_port:
     ensure  => $ensure,
-  } -> 
+  } ->
 
   wait_until_port_is_open { '2021':
     ensure  => $ensure,
@@ -77,5 +77,5 @@ class dynatrace::role::start_all_processes (
   wait_until_port_is_open { '9911':
     ensure  => $ensure,
   }
-  
+
 }

--- a/manifests/role/stop_all_processes.pp
+++ b/manifests/role/stop_all_processes.pp
@@ -32,11 +32,11 @@ class dynatrace::role::stop_all_processes (
       name   => $x,
     }
   }
-  
-  #TODO add lambda to delay execution on agent  
+
+  #TODO add lambda to delay execution on agent
   $services_to_stop_string = join($services_to_stop_array,",")
 #  notify{"server - stop all processes": message => "executing dynatrace::role::stop_all_processes  services_to_stop=${services_to_stop_string}"; }
-   
+
   stop_processes { "Stop the ${role_name} processes: ${services_to_stop_string}":
     services_to_stop      => $services_to_stop_string,
     installer_owner       => $dynatrace_owner,

--- a/manifests/role/uninstall_all.pp
+++ b/manifests/role/uninstall_all.pp
@@ -43,21 +43,21 @@ class dynatrace::role::uninstall_all (
   #stop all Dynatrace processes
   include dynatrace::role::stop_all_processes
 
-  #removing folders and links  
+  #removing folders and links
   exec {"remove directory using symlink=${symlink}":
     # remove directory using symlink (Puppet file resource does not work sometimes in this case)
     command => "rm -rf \"$(readlink ${symlink})\"; rm -rf ${symlink}",
     path    => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
     onlyif  => ["test -L ${symlink}"],
   } ->
-  
+
   file {"remove directory by symlink=${symlink}":
     path => $symlink,
     recurse => true,
     purge => true,
     force => true,
   } ->
-  
+
   tidy { 'clean /tmp folder from dynatrace files':
     path    => '/tmp',
     recurse => 1,
@@ -83,7 +83,7 @@ class dynatrace::role::uninstall_all (
     purge => true,
     force => true,
   }
-  
+
   file {"remove tmp dynatrace directory":
     ensure => absent,
     path => '/tmp/hsperfdata_dynatrace',

--- a/manifests/role/wsagent_package.pp
+++ b/manifests/role/wsagent_package.pp
@@ -10,7 +10,7 @@ class dynatrace::role::wsagent_package (
   $dynatrace_owner      = $dynatrace::dynatrace_owner,
   $dynatrace_group      = $dynatrace::dynatrace_group
 ) inherits dynatrace {
-  
+
   validate_re($ensure, ['^present$', '^absent$'])
   validate_string($installer_prefix_dir, $installer_file_name)
   validate_string($agent_name, $collector_hostname, $collector_port)
@@ -23,7 +23,7 @@ class dynatrace::role::wsagent_package (
     }
     default: {}
   }
-  
+
   $directory_ensure = $ensure ? {
     'present' => 'directory',
     'absent'  => 'absent',
@@ -35,7 +35,7 @@ class dynatrace::role::wsagent_package (
     'absent'  => 'uninstalled',
     default   => 'installed',
   }
-  
+
   $service_ensure = $ensure ? {
     'present' => 'running',
     'absent'  => 'stopped',
@@ -117,4 +117,3 @@ class dynatrace::role::wsagent_package (
     enable => true
   }
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,10 @@
     {
       "name": "maestrodev/wget",
       "version_requirement": ">= 1.7.1"
+    },
+    {
+      "name": "AlexCline/dirtree",
+      "version_requirement": ">= 0.2.1"
     }
   ]
 }

--- a/test/integration/agents_package/init.pp
+++ b/test/integration/agents_package/init.pp
@@ -3,6 +3,6 @@ class { 'java':
 }
 
 class { 'dynatrace::role::agents_package':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-agent-unix.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-agent-6.5.0.1289-unix.jar',
   require            => Class['java']
 }

--- a/test/integration/apache_wsagent_debian/init.pp
+++ b/test/integration/apache_wsagent_debian/init.pp
@@ -1,7 +1,7 @@
 class { 'apache': }
 
 class { 'dynatrace::role::wsagent_package':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-wsagent-linux-x86-64.tar'
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-wsagent-6.5.0.1289-linux-x86-64.tar'
 }
 
 class { 'dynatrace::role::apache_wsagent':

--- a/test/integration/apache_wsagent_redhat/init.pp
+++ b/test/integration/apache_wsagent_redhat/init.pp
@@ -1,7 +1,7 @@
 class { 'apache': }
 
 class { 'dynatrace::role::wsagent_package':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-wsagent-linux-x86-64.tar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-wsagent-6.5.0.1289-linux-x86-64.tar',
   require            => Class['apache']
 }
 

--- a/test/integration/collector/init.pp
+++ b/test/integration/collector/init.pp
@@ -7,7 +7,7 @@ class { 'java':
 }
 
 class { 'dynatrace::role::collector':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-collector-linux-x86.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-collector-6.5.0.1289-linux-x86.jar',
   jvm_xms            => '256M',
   jvm_xmx            => '1024M',
   jvm_perm_size      => '256m',

--- a/test/integration/java_agent/init.pp
+++ b/test/integration/java_agent/init.pp
@@ -3,7 +3,7 @@ class { 'java':
 }
 
 class { 'dynatrace::role::agents_package':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-agent-unix.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-agent-6.5.0.1289-unix.jar',
   require            => Class['java']
 }
 

--- a/test/integration/memory_analysis_server/init.pp
+++ b/test/integration/memory_analysis_server/init.pp
@@ -7,7 +7,7 @@ class { 'java':
 }
 
 class { 'dynatrace::role::memory_analysis_server':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-analysisserver-linux-x86.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-analysisserver-6.5.0.1289-linux-x86.jar',
   jvm_xms            => '256M',
   jvm_xmx            => '1024M',
   jvm_perm_size      => '256m',

--- a/test/integration/server/init.pp
+++ b/test/integration/server/init.pp
@@ -8,6 +8,6 @@ class { 'java':
 }
 
 class { 'dynatrace::role::server':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-server-linux-x86.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-server-6.5.0.1289-linux-x86.jar',
   require            => [ Class['ruby'], Class['java'] ]
 }

--- a/test/integration/server/init.pp
+++ b/test/integration/server/init.pp
@@ -9,6 +9,5 @@ class { 'java':
 
 class { 'dynatrace::role::server':
   installer_file_url => 'http://172.18.129.150:8000/dynatrace-server-linux-x86.jar',
-  do_pwh_connection  => true,
   require            => [ Class['ruby'], Class['java'] ]
 }

--- a/test/integration/server/serverspec/server_spec.rb
+++ b/test/integration/server/serverspec/server_spec.rb
@@ -91,11 +91,6 @@ describe 'Dynatrace Server Performance Warehouse Configuration' do
 
     data = JSON.parse(response.body)
     expect(data['pwhconnectionconfiguration']['host']).to eq('localhost')
-    expect(data['pwhconnectionconfiguration']['port']).to eq('5432')
-    expect(data['pwhconnectionconfiguration']['dbms']).to eq('postgresql')
-    expect(data['pwhconnectionconfiguration']['dbname']).to eq('dynatrace-pwh')
-    expect(data['pwhconnectionconfiguration']['user']).to eq('dynatrace')
-    expect(data['pwhconnectionconfiguration']['password']).to eq('*********')
-    expect(data['pwhconnectionconfiguration']['usessl']).to eq(false)
+    expect(data['pwhconnectionconfiguration']['dbms']).to eq('embedded')
   end
 end

--- a/test/integration/server_collector_agent/init.pp
+++ b/test/integration/server_collector_agent/init.pp
@@ -8,12 +8,12 @@ class { 'java':
 }
 
 class { 'dynatrace::role::server':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-server-linux-x86.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-server-6.5.0.1289-linux-x86.jar',
   require            => [ Class['ruby'], Class['java'] ]
 }
 
 class { 'dynatrace::role::collector':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-collector-linux-x86.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-collector-6.5.0.1289-linux-x86.jar',
   jvm_xms            => '256M',
   jvm_xmx            => '1024M',
   jvm_perm_size      => '256m',
@@ -22,6 +22,6 @@ class { 'dynatrace::role::collector':
 }
 
 class { 'dynatrace::role::agents_package':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-agent-unix.jar',
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-agent-6.5.0.1289-unix.jar',
   require            => [ Class['dynatrace::role::collector'] ]
 }

--- a/test/integration/server_collector_agent/init.pp
+++ b/test/integration/server_collector_agent/init.pp
@@ -9,7 +9,6 @@ class { 'java':
 
 class { 'dynatrace::role::server':
   installer_file_url => 'http://172.18.129.150:8000/dynatrace-server-linux-x86.jar',
-  do_pwh_connection  => true,
   require            => [ Class['ruby'], Class['java'] ]
 }
 

--- a/test/integration/server_collector_agent/serverspec/server_collector_agent_spec.rb
+++ b/test/integration/server_collector_agent/serverspec/server_collector_agent_spec.rb
@@ -144,11 +144,6 @@ describe 'Dynatrace Server Performance Warehouse Configuration' do
 
     data = JSON.parse(response.body)
     expect(data['pwhconnectionconfiguration']['host']).to eq('localhost')
-    expect(data['pwhconnectionconfiguration']['port']).to eq('5432')
-    expect(data['pwhconnectionconfiguration']['dbms']).to eq('postgresql')
-    expect(data['pwhconnectionconfiguration']['dbname']).to eq('dynatrace-pwh')
-    expect(data['pwhconnectionconfiguration']['user']).to eq('dynatrace')
-    expect(data['pwhconnectionconfiguration']['password']).to eq('*********')
-    expect(data['pwhconnectionconfiguration']['usessl']).to eq(false)
+    expect(data['pwhconnectionconfiguration']['dbms']).to eq('embedded')
   end
 end

--- a/test/integration/server_collector_agent/serverspec/server_collector_agent_spec.rb
+++ b/test/integration/server_collector_agent/serverspec/server_collector_agent_spec.rb
@@ -92,9 +92,9 @@ describe service('dynaTraceCollector') do
   it { should be_enabled }
 
   if os[:family] == 'debian' || os[:family] == 'ubuntu'
-      it { should be_enabled.with_level(3) }
-      it { should be_enabled.with_level(4) }
-      it { should be_enabled.with_level(5) }
+    it { should be_enabled.with_level(3) }
+    it { should be_enabled.with_level(4) }
+    it { should be_enabled.with_level(5) }
   end
 end
 
@@ -102,9 +102,9 @@ describe service('dynaTraceServer') do
   it { should be_enabled }
 
   if os[:family] == 'debian' || os[:family] == 'ubuntu'
-      it { should be_enabled.with_level(3) }
-      it { should be_enabled.with_level(4) }
-      it { should be_enabled.with_level(5) }
+    it { should be_enabled.with_level(3) }
+    it { should be_enabled.with_level(4) }
+    it { should be_enabled.with_level(5) }
   end
 end
 

--- a/test/integration/wsagent_package/init.pp
+++ b/test/integration/wsagent_package/init.pp
@@ -1,3 +1,3 @@
 class { 'dynatrace::role::wsagent_package':
-  installer_file_url => 'http://172.18.129.150:8000/dynatrace-wsagent-linux-x86-64.tar'
+  installer_file_url => 'https://files.dynatrace.com/downloads/OnPrem/dynaTrace/6.5/6.5.0.1289/dynatrace-wsagent-6.5.0.1289-linux-x86-64.tar'
 }


### PR DESCRIPTION
- Remove `do_pwh_connection` param from `server` manifest tests.
It was removed from the "dynatrace::role::server" class earlier by https://github.com/Dynatrace/Dynatrace-Puppet/commit/8e48bc9aa14fef2d0085d16c12827089775d1179.

- Rollback the "AlexCline/dirtree" dependency removal.
Seems like it was accidentally removed by  https://github.com/Dynatrace/Dynatrace-Puppet/commit/4828df58097ffa962cf229bbb6eb0cafb674ab8d. "dirtree" function is still in use in manifests.

- For tests, use publicly available installers' URLs.

- Fix serverspec tests for a "server" manifest.
PWH connection has been moved into a separate manifest by https://github.com/Dynatrace/Dynatrace-Puppet/commit/a47820f86225d89b59fc4af1a77623951de3e9ab and https://github.com/Dynatrace/Dynatrace-Puppet/commit/8e48bc9aa14fef2d0085d16c12827089775d1179, so now "server" manifest sets up the embedded dbms.

- Fix indentation, remove trailing spaces.

- Fix typo: "PHW" -> "PWH"