### PR TITLE
Issue #37: PID file directory is now a module param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,8 @@
 class dynatrace (
   $installer_cache_dir = $dynatrace::params::installer_cache_dir,
 
+  $pid_file_directory = $dynatrace::params::pid_file_directory,
+
   $agents_package_installer_bitsize    = $dynatrace::params::agents_package_installer_bitsize,
   $agents_package_installer_prefix_dir = $dynatrace::params::agents_package_installer_prefix_dir,
   $agents_package_installer_file_name  = $dynatrace::params::agents_package_installer_file_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,4 +94,10 @@ class dynatrace (
 
 ) inherits dynatrace::params {
 
+  if $pid_file_directory != '/tmp' {
+    file { $pid_file_directory :
+      ensure => 'directory',
+    }
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@
 #
 #  $apache_wsagent_apache_config_file_path     => The path to the Apache HTTP Server's config file.
 #  $apache_wsagent_linux_agent_path            => The path to the Dynatrace Agent library.
-#  
+#
 #  $collector_installer_bitsize    => '32' or '64'.
 #  $collector_installer_prefix_dir => The Dynatrace Collector will be installed into the directory $collector_installer_prefix_dir/dynatrace-$major-$minor-$rev, where $major, $minor and $rev are given by the installer. A symbolic link to the actual installation directory will be created in $collector_installer_prefix_dir/dynatrace.
 #  $collector_installer_file_name  => The file name of the Dynatrace Collector installer in the module's files directory.
@@ -26,14 +26,14 @@
 #  $collector_jvm_xmx              => The Dynatrace Collector's JVM setting: -Xmx.
 #  $collector_jvm_perm_size        => The Dynatrace Collector's JVM setting: -XX:PermSize.
 #  $collector_jvm_max_perm_size    => The Dynatrace Collector's JVM setting: -XX:MaxPermSize.
-#  
+#
 #  $java_agent_env_var_name       => The name of the environment variable to be used for Dynatrace Agent injection.
 #  $java_agent_env_var_file_name  => The name of the file to be modified.
 #  $java_agent_name               => The name of the Dynatrace Agent as it appears in the Dynatrace Server.
 #  $java_agent_collector_hostname => The location of the collector the Dynatrace Agent shall connect to.
 #  $java_agent_collector_port     => The port on the collector the Dynatrace Agent shall connect to.
 #  $java_agent_linux_agent_path   => The path to the Dynatrace Agent libary.
-#  
+#
 #  $memory_analysis_server_installer_bitsize    => '32' or '64'.
 #  $memory_analysis_server_installer_prefix_dir => The Dynatrace Memory Analysis Server will be installed into the directory $memory_analysis_server_installer_prefix_dir/dynatrace-$major-$minor-$rev, where $major, $minor and $rev are given by the installer. A symbolic link to the actual installation directory will be created in $memory_analysis_server_installer_prefix_dir/dynatrace.
 #  $memory_analysis_server_installer_file_name  => The file name of the Dynatrace Memory Analysis Server installer in the module's files directory.
@@ -43,7 +43,7 @@
 #  $memory_analysis_server_jvm_xmx              => The Dynatrace Memory Analysis Server's JVM setting: -Xmx.
 #  $memory_analysis_server_jvm_perm_size        => The Dynatrace Memory Analysis Server's JVM setting: -XX:PermSize.
 #  $memory_analysis_server_jvm_max_perm_size    => The Dynatrace Memory Analysis Server's JVM setting: -XX:MaxPermSize.
-#  
+#
 #  $server_installer_bitsize       => '32' or '64'.
 #  $server_installer_prefix_dir    => The Dynatrace Server will be installed into the directory $server_installer_prefix_dir/dynatrace-$major-$minor-$rev, where $major, $minor and $rev are given by the installer. A symbolic link to the actual installation directory will be created in $server_installer_prefix_dir/dynatrace.
 #  $server_installer_file_name     => The file name of the Dynatrace installer in the cookbook's files directory.
@@ -58,7 +58,7 @@
 #  $server_pwh_connection_database =>
 #  $server_pwh_connection_username =>
 #  $server_pwh_connection_password =>
-#  
+#
 #  $wsagent_package_agent_name           => The name the Dynatrace WebServer Agent as it appears in the Dynatrace Server.
 #  $wsagent_package_collector_hostname   => The location of the Dynatrace Collector the Web Server Agent shall connect to.
 #  $wsagent_package_collector_port       => The port on the Dynatrace Collector the Web Server Agent shall connect to.
@@ -71,12 +71,12 @@
 #  $host_agent_installer_file_url   => A HTTP, HTTPS or FTP URL to the Dynatrace Web Host Agent installer in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path.
 #  $host_agent_name                 => Dynatrace Host Agent name
 #  $host_agent_collector            => Dynatrace Host Agent Collector identifier (collector IP address or host name)
-#  
+#
 #  $update_file_url                 => URL to the update zip file with tds inside e.g. 'https://files.dynatrace.com/downloads/fixpacks/dynaTrace-6.5.1.1003.zip'
-#  $update_rest_url                 => the REST URL to perform update 
-#  $update_user                     => user name 
+#  $update_rest_url                 => the REST URL to perform update
+#  $update_user                     => user name
 #  $update_passwd                   => user password
-#  
+#
 class dynatrace::params {
   $dynatrace_version = '7.0.0.2469'
   $dynatrace_version_link = "7.0/${dynatrace_version}"
@@ -85,6 +85,7 @@ class dynatrace::params {
       $dynatrace_owner = 'dynatrace'
       $dynatrace_group = 'dynatrace'
       $installer_cache_dir = $settings::vardir
+      $pid_file_directory  = '/tmp'
 
       $agents_package_installer_bitsize    = '64'
       $agents_package_installer_prefix_dir = '/opt'

--- a/templates/init.d/dynaTraceAnalysis.erb
+++ b/templates/init.d/dynaTraceAnalysis.erb
@@ -33,7 +33,7 @@ DT_RUNASUSER=<%= @params["user"] %>
 # How long to wait for shutdown
 DT_SHUTDOWN_WAIT=60
 
-DT_PIDFILE_DIR=/tmp
+DT_PIDFILE_DIR=<%= @dynatrace::pid_file_directory %>
 
 DT_PIDFILE=${DT_PIDFILE_DIR}/${DT_BINARY}63.pid
 
@@ -56,11 +56,11 @@ case "$1" in
       echo "${DT_HOME}"/${DT_BINARY} -bg ${DT_OPTARGS}
       "${DT_HOME}"/${DT_BINARY} -bg ${DT_OPTARGS}
       echo $! >${DT_PIDFILE}
-    else  
+    else
       echo "${DT_HOME}"/${DT_BINARY} -bg ${DT_OPTARGS}
       su -c "${DT_HOME}/${DT_BINARY} -bg ${DT_OPTARGS}" "${DT_RUNASUSER}"
       echo $! >${DT_PIDFILE}
-    fi    
+    fi
   else
     echo "Dynatrace ${DT_PRODUCT} daemon is already running!"
   fi
@@ -83,7 +83,7 @@ case "$1" in
       kill -9 ${PROCESSPID}
     fi
 
-    if [ -f "${DT_PIDFILE}" ]; then 
+    if [ -f "${DT_PIDFILE}" ]; then
       rm -f ${DT_PIDFILE}
     fi
   fi

--- a/templates/init.d/dynaTraceBackendServer.erb
+++ b/templates/init.d/dynaTraceBackendServer.erb
@@ -33,7 +33,7 @@ DT_RUNASUSER=<%= @params["user"] %>
 # How long to wait for shutdown
 DT_SHUTDOWN_WAIT=60
 
-DT_PIDFILE_DIR=/tmp
+DT_PIDFILE_DIR=<%= @dynatrace::pid_file_directory %>
 
 DT_PIDFILE=${DT_PIDFILE_DIR}/${DT_BINARY}63.pid
 
@@ -59,11 +59,11 @@ case "$1" in
       echo "${DT_HOME}"/${DT_BINARY} -bg ${DT_OPTARGS}
       "${DT_HOME}"/${DT_BINARY} -bg ${DT_OPTARGS}
       echo $! >${DT_PIDFILE}
-    else  
+    else
       echo "${DT_HOME}"/${DT_BINARY} -bg ${DT_OPTARGS}
       su -c "${DT_HOME}/${DT_BINARY} -bg ${DT_OPTARGS}" "${DT_RUNASUSER}"
       echo $! >${DT_PIDFILE}
-    fi    
+    fi
   else
     echo "Dynatrace ${DT_PRODUCT} daemon is already running!"
   fi
@@ -86,7 +86,7 @@ case "$1" in
       kill -9 ${PROCESSPID}
     fi
 
-    if [ -f "${DT_PIDFILE}" ]; then   
+    if [ -f "${DT_PIDFILE}" ]; then
       rm -f ${DT_PIDFILE}
     fi
   fi

--- a/templates/init.d/dynaTraceCollector.erb
+++ b/templates/init.d/dynaTraceCollector.erb
@@ -6,7 +6,7 @@
 #
 # Copy this script to /etc/init.d and use chkconfig for enabling/disabling
 # the daemon. In order to run multiple Collectors on the same host,
-# further adjustments may be necessary. Depending on the target environment 
+# further adjustments may be necessary. Depending on the target environment
 # adjustments may be necessary.
 #
 ### BEGIN INIT INFO
@@ -40,7 +40,7 @@ DT_SHUTDOWN_WAIT=60
 
 OS_TYPE=`uname`
 
-DT_PIDFILE_DIR=/tmp
+DT_PIDFILE_DIR=<%= @dynatrace::pid_file_directory %>
 
 DT_PIDFILE=${DT_PIDFILE_DIR}/${DT_BINARY}63.pid
 if [ -n "${DT_INSTANCE}" ]; then
@@ -80,23 +80,23 @@ case "$1" in
           su "${DT_RUNASUSER}" -c "${DT_HOME}/${DT_BINARY} -bg ${DT_OPTARGS}"
         else
           su -c "${DT_HOME}/${DT_BINARY} -bg ${DT_OPTARGS}" "${DT_RUNASUSER}"
-        fi      
+        fi
         echo $! >${DT_PIDFILE}
-      fi  
+      fi
     else
       if [ -z "${DT_RUNASUSER}" ]; then
         echo "${DT_HOME}"/${DT_BINARY} -instance "${DT_INSTANCE}" -bg ${DT_OPTARGS}
         "${DT_HOME}"/${DT_BINARY} -instance "${DT_INSTANCE}" -bg ${DT_OPTARGS}
         echo $! >${DT_PIDFILE}
-      else        
+      else
         echo "${DT_HOME}"/${DT_BINARY} -instance "${DT_INSTANCE}" -bg ${DT_OPTARGS}
         if [ "$OS_TYPE" = 'SunOS' ]; then
           su "${DT_RUNASUSER}" -c "${DT_HOME}/${DT_BINARY} -instance ${DT_INSTANCE} -bg ${DT_OPTARGS}"
         else
           su -c "${DT_HOME}/${DT_BINARY} -instance ${DT_INSTANCE} -bg ${DT_OPTARGS}" "${DT_RUNASUSER}"
-        fi    
+        fi
         echo $! >${DT_PIDFILE}
-      fi  
+      fi
     fi
   else
     echo "Dynatrace ${DT_PRODUCT} daemon is already running!"
@@ -120,7 +120,7 @@ case "$1" in
       kill -9 ${PROCESSPID}
     fi
 
-    if [ -f "${DT_PIDFILE}" ]; then 
+    if [ -f "${DT_PIDFILE}" ]; then
       rm -f ${DT_PIDFILE}
     fi
   fi

--- a/templates/init.d/dynaTraceFrontendServer.erb
+++ b/templates/init.d/dynaTraceFrontendServer.erb
@@ -33,7 +33,7 @@ DT_BINARY=dtfrontendserver
 # How long to wait for shutdown
 DT_SHUTDOWN_WAIT=60
 
-DT_PIDFILE_DIR=/tmp
+DT_PIDFILE_DIR=<%= @dynatrace::pid_file_directory %>
 
 DT_PIDFILE=${DT_PIDFILE_DIR}/${DT_BINARY}63.pid
 
@@ -73,7 +73,7 @@ case "$1" in
   if [ -n "${PROCESSPID}" ]; then
     echo "Terminating Dynatrace $DT_PRODUCT process ${PROCESSPID}"
     kill -15 ${PROCESSPID}
- 
+
     COUNT=0;
     while [ `ps -A -o pid | grep -c ${PROCESSPID}` -gt 0 ] && [ "${COUNT}" -lt "${DT_SHUTDOWN_WAIT}" ] # `ps --pid ${PROCESSPID} | grep -c ${PROCESSPID}` -ne 0]
     do

--- a/templates/init.d/dynaTraceServer.erb
+++ b/templates/init.d/dynaTraceServer.erb
@@ -40,7 +40,7 @@ DT_RUNASUSER=<%= @params["user"] %>
 # How long to wait for shutdown
 DT_SHUTDOWN_WAIT=60
 
-DT_PIDFILE_DIR=/tmp
+DT_PIDFILE_DIR=<%= @dynatrace::pid_file_directory %>
 
 DT_PIDFILE=${DT_PIDFILE_DIR}/${DT_BINARY}63.pid
 

--- a/templates/init.d/dynaTraceWebServerAgent.erb
+++ b/templates/init.d/dynaTraceWebServerAgent.erb
@@ -31,7 +31,7 @@ DT_RUNASUSER=<%= @params["user"] %>
 
 DT_SHUTDOWN_WAIT=60
 
-DT_PIDFILE_DIR=/tmp
+DT_PIDFILE_DIR=<%= @dynatrace::pid_file_directory %>
 
 DT_PIDFILE=${DT_PIDFILE_DIR}/${DT_BINARY}63.pid
 
@@ -75,7 +75,7 @@ case "$1" in
       su -c "nohup ${DT_BINARY_WITH_PATH} ${DT_OPTARGS} >/dev/null 2>&1 &" "${DT_RUNASUSER}"
     fi
     echo $! >${DT_PIDFILE}
-  fi    
+  fi
   ;;
 'stop')
   if [ -n "${PROCESSPID}" ]; then
@@ -95,7 +95,7 @@ case "$1" in
       kill -9 ${PROCESSPID}
     fi
 
-    if [ -f "${DT_PIDFILE}" ]; then 
+    if [ -f "${DT_PIDFILE}" ]; then
       rm -f ${DT_PIDFILE}
     fi
   fi


### PR DESCRIPTION
Users of this module now have the option to set a different directory for the PID file of the various Dynatrace services. The default is still '/tmp' but is recommended to be overwritten to something like:
```yaml
dynatrace::pid_file_directory: '/var/run/dynatrace'
```
With this PR, if the value is overwritten to be something else than '/tmp', the Puppet module will ensure that the directory exists via a File resource. To ensure that the service status is still working during the migration, the services should be stopped or the pid files copied from /tmp to the new directory before running Puppet with a different value than '/tmp'.